### PR TITLE
Fix NoneType iteration issue

### DIFF
--- a/lavalink/rest_api.py
+++ b/lavalink/rest_api.py
@@ -59,7 +59,7 @@ class RESTClient:
         }
 
     def _tracks_from_resp(self, resp) -> Tuple[Track, ...]:
-        return tuple(Track(d) for d in resp)
+        return tuple(Track(d) for d in resp) if resp else tuple([])
 
     async def get_tracks(self, query):
         """


### PR DESCRIPTION
When no results are found, resp is a NoneType, and this leads to an exception.