### PR TITLE
Work with lavalink v3

### DIFF
--- a/lavalink/lavalink.py
+++ b/lavalink/lavalink.py
@@ -72,6 +72,8 @@ async def initialize(bot: Bot, host, password, rest_port, ws_port, timeout=30):
 
     bot.add_listener(player_manager.on_socket_response)
 
+    return lavalink_node
+
 
 def register_event_listener(coro):
     """

--- a/lavalink/node.py
+++ b/lavalink/node.py
@@ -188,6 +188,11 @@ class Node:
     def _get_connect_headers(password, user_id, num_shards):
         return {"Authorization": password, "User-Id": user_id, "Num-Shards": num_shards}
 
+    @property
+    def lavalink_major_version(self):
+        assert self._ws, "not connected"
+        return self._ws.response_headers.get("Lavalink-Major-Version")
+
     async def _multi_try_connect(self, uri):
         backoff = ExponentialBackoff()
         attempt = 1

--- a/lavalink/node.py
+++ b/lavalink/node.py
@@ -355,6 +355,10 @@ def get_node(guild_id: int) -> Node:
     """
     guild_count = 1e10
     least_used = None
+
+    if not _nodes:
+        raise IndexError("No nodes found.")
+
     for node, guild_ids in _nodes.items():
         if len(guild_ids) < guild_count:
             guild_count = len(guild_ids)

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -97,8 +97,13 @@ class Player(RESTClient):
         """
         Disconnects this player from it's voice channel.
         """
-        await node.join_voice(self.channel.guild.id, None)
-        await self._node.destroy_guild(self.channel.guild.id)
+        guild_id = self.channel.guild.id
+        voice_ws = self._node.voice_ws_func(guild_id)
+
+        if not voice_ws.closed:
+            await voice_ws.voice_state(guild_id, None)
+
+        await self._node.destroy_guild(guild_id)
         await self.close()
 
     def store(self, key, value):

--- a/lavalink/rest_api.py
+++ b/lavalink/rest_api.py
@@ -8,7 +8,7 @@ from . import log
 
 from urllib.parse import quote
 
-__all__ = ['Track', 'RESTClient', 'LoadType', 'PlaylistInfo']
+__all__ = ["Track", "RESTClient", "LoadType", "PlaylistInfo"]
 
 
 PlaylistInfo = namedtuple("PlaylistInfo", "name selectedTrack")

--- a/lavalink/rest_api.py
+++ b/lavalink/rest_api.py
@@ -1,12 +1,38 @@
 from typing import Tuple
 
 from aiohttp import ClientSession
+from collections import namedtuple
+from enum import Enum
 
 from . import log
 
 from urllib.parse import quote
 
-__all__ = ['Track', 'RESTClient']
+__all__ = ['Track', 'RESTClient', 'LoadType', 'PlaylistInfo']
+
+
+PlaylistInfo = namedtuple("PlaylistInfo", "name selectedTrack")
+
+
+class LoadType(Enum):
+    """
+    The result type of a loadtracks request
+
+    Attributes
+    ----------
+    TRACK_LOADED
+    TRACK_LOADED
+    PLAYLIST_LOADED
+    SEARCH_RESULT
+    NO_MATCHES
+    LOAD_FAILED
+    """
+
+    TRACK_LOADED = "TRACK_LOADED"
+    PLAYLIST_LOADED = "PLAYLIST_LOADED"
+    SEARCH_RESULT = "SEARCH_RESULT"
+    NO_MATCHES = "NO_MATCHES"
+    LOAD_FAILED = "LOAD_FAILED"
 
 
 class Track:
@@ -55,6 +81,32 @@ class Track:
             return "https://img.youtube.com/vi/{}/mqdefault.jpg".format(self._info["identifier"])
 
 
+class LoadResult:
+    """
+    The result of a load_tracks request.
+
+    Attributes
+    ----------
+    load_type : LoadType
+        The result of the loadtracks request
+    playlist_info : Optional[PlaylistInfo]
+        The playlist information detected by Lavalink
+    tracks : Tuple[Track, ...]
+        The tracks that were loaded, if any
+    """
+
+    def __init__(self, data):
+        self._raw = data
+        self.load_type = LoadType(data["loadType"])
+
+        if data.get("playlistInfo"):
+            self.playlist_info = PlaylistInfo(**data["playlistInfo"])
+        else:
+            self.playlist_info = None
+
+        self.tracks = tuple(Track(t) for t in data["tracks"])
+
+
 class RESTClient:
     """
     Client class used to access the REST endpoints on a Lavalink node.
@@ -66,7 +118,27 @@ class RESTClient:
         self._uri = "http://{}:{}/loadtracks?identifier=".format(node.host, node.rest)
         self._headers = {"Authorization": node.password}
 
-    async def get_tracks(self, query):
+    async def load_tracks(self, query) -> LoadResult:
+        """
+        Executes a loadtracks request. Only works on Lavalink V3.
+
+        Parameters
+        ----------
+        query : str
+
+        Returns
+        -------
+        LoadResult
+        """
+        url = self._uri + quote(str(query))
+
+        async with self._session.get(url, headers=self._headers) as resp:
+            data = await resp.json(content_type=None)
+
+        assert type(data) is dict, "Lavalink V3 is required for this method"
+        return LoadResult(data)
+
+    async def get_tracks(self, query) -> Tuple[Track, ...]:
         """
         Gets tracks from lavalink.
 
@@ -76,16 +148,15 @@ class RESTClient:
 
         Returns
         -------
-        list of dict
+        Tuple[Track, ...]
         """
         url = self._uri + quote(str(query))
+
         async with self._session.get(url, headers=self._headers) as resp:
             data = await resp.json(content_type=None)
-            if data is not None:
-                tracks = tuple(Track(d) for d in data)
-            else:
-                tracks = ()
-        return tracks
+
+        tracks = data["tracks"] if type(data) is dict else data
+        return tuple(Track(t) for t in tracks)
 
     async def search_yt(self, query) -> Tuple[Track, ...]:
         """

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def get_requirements():
 
 setup(
     name="Red-Lavalink",
-    version="0.1.2",
+    version="0.2.0",
     packages=["lavalink"],
     url="https://github.com/Cog-Creators/Red-Lavalink",
     license="GPLv3",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,7 @@ async def node(bot):
         host="localhost",
         password="password",
         port=2333,
-        rest=2332,
+        rest=2333,
         user_id=bot.user.id,
         num_shards=bot.shard_count,
     )
@@ -122,6 +122,6 @@ async def node(bot):
 @pytest.fixture()
 @async_generator
 async def initialize_lavalink(bot):
-    await lavalink.initialize(bot, "localhost", "password", 2332, 2333)
+    await lavalink.initialize(bot, "localhost", "password", 2333, 2333)
     await yield_(None)
     await lavalink.close()

--- a/tests/test_lavalink.py
+++ b/tests/test_lavalink.py
@@ -7,7 +7,7 @@ import lavalink.node
 
 @pytest.mark.asyncio
 async def test_initialize(bot):
-    await lavalink.initialize(bot, "localhost", "password", 2332, 2333)
+    await lavalink.initialize(bot, "localhost", "password", 2333, 2333)
 
     assert lavalink.player_manager.user_id == bot.user.id
     assert lavalink.player_manager.channel_finder_func == bot.get_channel


### PR DESCRIPTION
Tested and working with both Lavalink version 2 and 3. Since both the websocket and REST server are on the same port in v3, the websocket port needs to be changed in Red. The `initialize()` method now returns the Node so that the version can be checked once the connection has been established.