### PR TITLE
raise an exception when no nodes have been started

### DIFF
--- a/lavalink/node.py
+++ b/lavalink/node.py
@@ -165,8 +165,7 @@ class Node:
         self._listener_task = None
 
         self._queue = []
-
-        _nodes[self] = []
+        self._players = set()
 
     async def connect(self, timeout=None):
         """
@@ -198,6 +197,8 @@ class Node:
             with contextlib.suppress(Exception):
                 if await cast(Awaitable[Optional[websockets.WebSocketClientProtocol]], task):
                     break
+
+        _nodes[self] = []
 
         log.debug("Creating Lavalink WS listener.")
         self._listener_task = self.loop.create_task(self.listener())
@@ -304,8 +305,11 @@ class Node:
         if self._ws is not None and self._ws.open:
             await self._ws.close()
 
-        del _nodes[self]
-        log.debug("Shutdown Lavalink WS.")
+        while self._players:
+            await self._players.pop().destroy()
+
+        if _nodes.pop(self, None):
+            log.debug("Shutdown Lavalink WS.")
 
     async def send(self, data):
         if self._ws is None or not self._ws.open:

--- a/lavalink/node.py
+++ b/lavalink/node.py
@@ -374,12 +374,20 @@ def get_node(guild_id: int) -> Node:
     ----------
     guild_id : int
 
+    Raises
+    ------
+    IndexError
+        If no Nodes have been instantiated yet.
+
     Returns
     -------
     Node
     """
     guild_count = 1e10
     least_used = None
+
+    if not _nodes:
+        raise IndexError("no Nodes have been instantiated")
 
     for node, guild_ids in _nodes.items():
         if not node.ready.is_set():


### PR DESCRIPTION
This is a step towards resolving Cog-Creators/Red-DiscordBot#2306. For the cog to be able to connect in the background, operations like `lavalink.connect()` need to fail when trying to call `get_node()`, which currently returns `None` if  `_nodes` is empty. This is a problem because several other places in the code assume that a `Node` will always be returned. In the case handled here, an exception would still be raised, but it would be an `AttributeError` down the line instead of at the true point of failure.