### PR TITLE
Only return a node or player if it is ready

### DIFF
--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -11,4 +11,4 @@ try:
 except ImportError:
     pass
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -1,4 +1,6 @@
+import asyncio
 from random import randrange
+from typing import Optional
 
 import discord
 
@@ -72,6 +74,33 @@ class Player(RESTClient):
         The current volume.
         """
         return self._volume
+
+    @property
+    def ready(self) -> bool:
+        """
+        Whether the underlying node is ready for requests.
+        """
+        return self._node.ready.is_set()
+
+    async def wait_until_ready(
+        self, timeout: Optional[float] = None, no_raise: bool = False
+    ) -> bool:
+        """
+        Waits for the underlying node to become ready.
+
+        If no_raise is set, returns false when a timeout occurs instead of propogating TimeoutError.
+        A timeout of None means to wait indefinitely.
+        """
+        if self._node.ready.is_set():
+            return True
+
+        try:
+            return await self._node.wait_until_ready(timeout=timeout)
+        except asyncio.TimeoutError:
+            if no_raise:
+                return False
+            else:
+                raise
 
     async def connect(self):
         """


### PR DESCRIPTION
@aikaterna uncovered a bug in my Audio PR (Cog-Creators/Red-DiscordBot#2335) where requests would still be made to Lavalink while it was trying to connect. Since they all use the `connect()` method, which in turn uses the internal `get_node()` function, the easiest fix is to not allow it to use a node until it's marked itself as connected.

The `connect()` function itself only instructs the bot to join the channel, so a Lavalink failure doesn't manifest until later. It's better not to create a Player for the node until it's connected.

I also added some helper functions in case someone wants to have the UI spin waiting for a connection instead of failing immediately.