### PR TITLE
Release v0.2.3: raise timeout when reconnect loops stop trying

### DIFF
--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -11,4 +11,4 @@ try:
 except ImportError:
     pass
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"

--- a/lavalink/node.py
+++ b/lavalink/node.py
@@ -175,7 +175,8 @@ class Node:
         ----------
         timeout : int
             Time after which to timeout on attempting to connect to the Lavalink websocket,
-            ``None`` is considered never.
+            ``None`` is considered never, but the underlying code may stop trying past a
+            certain point.
 
         Raises
         ------
@@ -197,6 +198,8 @@ class Node:
             with contextlib.suppress(Exception):
                 if await cast(Awaitable[Optional[websockets.WebSocketClientProtocol]], task):
                     break
+        else:
+            raise asyncio.TimeoutError
 
         _nodes[self] = []
 


### PR DESCRIPTION
Fixes the issue aika was having with Cog-Creators/Red-DiscordBot#2460 when no LL connection can be established after initial connection timeouts are reached.