### PR TITLE
Support lavalink V3 friendly exceptions and merge V2/V3 functionality

### DIFF
--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -11,4 +11,4 @@ from .enums import NodeState, PlayerState, TrackEndReason, LavalinkEvents
 from .rest_api import Track
 from . import utils
 
-__version__ = "0.2.3"
+__version__ = "0.3.0"

--- a/lavalink/enums.py
+++ b/lavalink/enums.py
@@ -123,6 +123,7 @@ class LoadType(enum.Enum):
     SEARCH_RESULT = "SEARCH_RESULT"
     NO_MATCHES = "NO_MATCHES"
     LOAD_FAILED = "LOAD_FAILED"
+    V2_COMPAT = "V2_COMPAT"
 
 
 class ExceptionSeverity(enum.Enum):

--- a/lavalink/enums.py
+++ b/lavalink/enums.py
@@ -8,6 +8,8 @@ __all__ = [
     "LavalinkOutgoingOp",
     "NodeState",
     "PlayerState",
+    "LoadType",
+    "ExceptionSeverity",
 ]
 
 
@@ -100,3 +102,30 @@ class PlayerState(enum.Enum):
     NODE_BUSY = 2
     RECONNECTING = 3
     DISCONNECTING = 4
+
+
+class LoadType(enum.Enum):
+    """
+    The result type of a loadtracks request
+
+    Attributes
+    ----------
+    TRACK_LOADED
+    TRACK_LOADED
+    PLAYLIST_LOADED
+    SEARCH_RESULT
+    NO_MATCHES
+    LOAD_FAILED
+    """
+
+    TRACK_LOADED = "TRACK_LOADED"
+    PLAYLIST_LOADED = "PLAYLIST_LOADED"
+    SEARCH_RESULT = "SEARCH_RESULT"
+    NO_MATCHES = "NO_MATCHES"
+    LOAD_FAILED = "LOAD_FAILED"
+
+
+class ExceptionSeverity(enum.Enum):
+    COMMON = "COMMON"
+    SUSPICIOUS = "SUSPICIOUS"
+    FATAL = "FATAL"

--- a/lavalink/node.py
+++ b/lavalink/node.py
@@ -141,7 +141,8 @@ class Node:
 
     @property
     def lavalink_major_version(self):
-        assert self._ws, "not connected"
+        if self.state != NodeState.READY:
+            raise RuntimeError("Node not ready!")
         return self._ws.response_headers.get("Lavalink-Major-Version")
 
     async def _multi_try_connect(self, uri):

--- a/lavalink/rest_api.py
+++ b/lavalink/rest_api.py
@@ -198,7 +198,7 @@ class RESTClient:
         result = await self.load_tracks(query)
         return result.tracks
 
-    async def search_yt(self, query) -> Tuple[Track, ...]:
+    async def search_yt(self, query) -> LoadResult:
         """
         Gets track results from YouTube from Lavalink.
 
@@ -210,9 +210,9 @@ class RESTClient:
         -------
         list of Track
         """
-        return await self.get_tracks("ytsearch:{}".format(query))
+        return await self.load_tracks("ytsearch:{}".format(query))
 
-    async def search_sc(self, query) -> Tuple[Track, ...]:
+    async def search_sc(self, query) -> LoadResult:
         """
         Gets track results from SoundCloud from Lavalink.
 
@@ -224,7 +224,7 @@ class RESTClient:
         -------
         list of Track
         """
-        return await self.get_tracks("scsearch:{}".format(query))
+        return await self.load_tracks("scsearch:{}".format(query))
 
     async def close(self):
         if self._session is not None:

--- a/lavalink/rest_api.py
+++ b/lavalink/rest_api.py
@@ -81,9 +81,15 @@ class LoadResult:
         self._raw = data
         self.load_type = LoadType(data["loadType"])
 
-        if data.get("playlistInfo"):
+        is_playlist = self._raw.get("isPlaylist")
+        if is_playlist is True:
+            self.is_playlist = True
             self.playlist_info = PlaylistInfo(**data["playlistInfo"])
+        elif is_playlist is False:
+            self.is_playlist = False
+            self.playlist_info = None
         else:
+            self.is_playlist = None
             self.playlist_info = None
 
         self.tracks = tuple(Track(t) for t in data["tracks"])


### PR DESCRIPTION
`get_tracks()` is now deprecated and should be switched to `load_tracks()` for V2 and V3.

## Breaking
Due to that switch, both of the `search_` methods will now return a `LoadResult` object instead of a list of tracks.

The `LoadResult` object returned from `load_tracks()` now has a few new attributes to support friendly exceptions:
 * `result.has_error`
 * `result.exception_message`
 * `result.exception_severity`