### PR TITLE
Some fixes and extended functionality

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,36 @@ Usage
         player.add(tracks[0])
         await player.play()
 
+*********
+Shuffling
+*********
+.. code-block:: python
+
+    def shuffle_queue(player_id, forced=True):
+        player = lavalink.get_player(player_id)
+        if not forced:
+            player.maybe_shuffle(sticky_songs=0)
+            """
+            `player.maybe_shuffle` respects `player.shuffle`
+            And will only shuffle if `player.shuffle` is True.
+
+            `player.maybe_shuffle` should be called every time
+            you would expect the queue to be shuffled.
+
+            `sticky_songs=0` will shuffle every song in the queue.
+            """
+        else:
+            player.force_shuffle(sticky_songs=3)
+            """
+            `player.force_shuffle` does not respect `player.shuffle`
+            And will always shuffle the queue.
+
+            `sticky_songs=3` will shuffle every song after the first 3 songs in the queue.
+            """
+
+
+
+
 When shutting down, be sure to do the following::
 
     await lavalink.close()

--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -11,4 +11,4 @@ from .enums import NodeState, PlayerState, TrackEndReason, LavalinkEvents
 from .rest_api import Track
 from . import utils
 
-__version__ = "0.3.2"
+__version__ = "0.4.0"

--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -11,4 +11,4 @@ from .enums import NodeState, PlayerState, TrackEndReason, LavalinkEvents
 from .rest_api import Track
 from . import utils
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/lavalink/lavalink.py
+++ b/lavalink/lavalink.py
@@ -1,13 +1,10 @@
 import asyncio
-from typing import List, Tuple
-
-from . import log
-from . import node
-from . import enums
-from . import player_manager
+from typing import Tuple
 
 import discord
 from discord.ext.commands import Bot
+
+from . import enums, log, node, player_manager
 
 __all__ = [
     "initialize",

--- a/lavalink/node.py
+++ b/lavalink/node.py
@@ -9,9 +9,8 @@ from discord.backoff import ExponentialBackoff
 
 from . import log, socket_log
 from .enums import *
-from .rest_api import Track
 from .player_manager import PlayerManager
-
+from .rest_api import Track
 
 __all__ = ["Stats", "Node", "get_node", "join_voice"]
 

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -262,6 +262,8 @@ class Player(RESTClient):
             self.current = track
             log.debug("Assigned current.")
             await self.node.play(self.channel.guild.id, track)
+            if track.start_timestamp > 0:
+                await self.seek(track.start_timestamp)
 
     async def stop(self):
         """

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -1,15 +1,12 @@
 import asyncio
-
 from random import shuffle
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 import discord
 
 from . import log
 from .enums import *
-from .rest_api import Track, RESTClient
-
-from typing import TYPE_CHECKING
+from .rest_api import RESTClient, Track
 
 if TYPE_CHECKING:
     from . import node

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -239,7 +239,7 @@ class Player(RESTClient):
         sticky = max(0, sticky_songs)  # Songs to  bypass shuffle
         if self.shuffle and self.queue:  # Keeps queue order consistent unless adding new tracks
             if sticky > 0:
-                to_keep = [self.queue[sticky-1]]
+                to_keep = [self.queue[sticky - 1]]
                 to_shuffle = self.queue[sticky:]
             else:
                 to_shuffle = self.queue

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -46,7 +46,7 @@ class Player(RESTClient):
         self.current = None  # type: Track
         self._paused = False
         self.repeat = False
-        self.shuffle = False
+        self.shuffle = False  # Shuffle is done client side now This is a breaking change
 
         self._volume = 100
 

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -236,8 +236,12 @@ class Player(RESTClient):
         self.queue.append(track)
 
     def maybe_shuffle(self, sticky_songs: int = 1):
-        sticky = max(0, sticky_songs)  # Songs to  bypass shuffle
         if self.shuffle and self.queue:  # Keeps queue order consistent unless adding new tracks
+            self.force_shuffle(sticky_songs)
+
+    def force_shuffle(self, sticky_songs: int = 1):
+        sticky = max(0, sticky_songs)  # Songs to  bypass shuffle
+        if self.queue:  # Keeps queue order consistent unless adding new tracks
             if sticky > 0:
                 to_keep = [self.queue[sticky - 1]]
                 to_shuffle = self.queue[sticky:]

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -234,12 +234,21 @@ class Player(RESTClient):
         """
         track.requester = requester
         self.queue.append(track)
+
+    def maybe_shuffle(self, sticky_songs: int = 1):
+        sticky = max(0, sticky_songs)  # Songs to  bypass shuffle
         if self.shuffle and self.queue:  # Keeps queue order consistent unless adding new tracks
-            first = self.queue.pop(0)
+            if sticky > 0:
+                to_keep = [self.queue[sticky-1]]
+                to_shuffle = self.queue[sticky:]
+            else:
+                to_shuffle = self.queue
+                to_keep = []
             # Shuffles whole queue
-            shuffle(self.queue)
+            shuffle(to_shuffle)
+            to_keep.extend(to_shuffle)
             # Keep next track in queue consistent while adding new tracks
-            self.queue.insert(0, first)
+            self.queue = to_keep
 
     async def play(self):
         """

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from random import randrange
+from random import shuffle
 from typing import Optional
 
 import discord
@@ -253,10 +253,10 @@ class Player(RESTClient):
             await self.stop()
         else:
             self._is_playing = True
+
+            track = self.queue.pop(0)
             if self.shuffle:
-                track = self.queue.pop(randrange(len(self.queue)))
-            else:
-                track = self.queue.pop(0)
+                shuffle(self.queue)
 
             self.current = track
             log.debug("Assigned current.")

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -234,8 +234,12 @@ class Player(RESTClient):
         """
         track.requester = requester
         self.queue.append(track)
-        if self.shuffle:
-            shuffle(self.queue)  # Keeps queue order consistent unless adding new tracks
+        if self.shuffle and self.queue:  # Keeps queue order consistent unless adding new tracks
+            first = self.queue.pop(0)
+            # Shuffles whole queue
+            shuffle(self.queue)
+            # Keep next track in queue consistent while adding new tracks
+            self.queue.insert(0, first)
 
     async def play(self):
         """

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -237,6 +237,8 @@ class Player(RESTClient):
         """
         track.requester = requester
         self.queue.append(track)
+        if self.shuffle:
+            shuffle(self.queue)  # Keeps queue order consistent unless adding new tracks
 
     async def play(self):
         """
@@ -255,8 +257,6 @@ class Player(RESTClient):
             self._is_playing = True
 
             track = self.queue.pop(0)
-            if self.shuffle:
-                shuffle(self.queue)
 
             self.current = track
             log.debug("Assigned current.")

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -243,7 +243,7 @@ class Player(RESTClient):
         sticky = max(0, sticky_songs)  # Songs to  bypass shuffle
         if self.queue:  # Keeps queue order consistent unless adding new tracks
             if sticky > 0:
-                to_keep = [self.queue[sticky - 1]]
+                to_keep = self.queue[:sticky]
                 to_shuffle = self.queue[sticky:]
             else:
                 to_shuffle = self.queue

--- a/lavalink/rest_api.py
+++ b/lavalink/rest_api.py
@@ -15,7 +15,7 @@ __all__ = ["Track", "RESTClient", "PlaylistInfo"]
 PlaylistInfo = namedtuple("PlaylistInfo", "name selectedTrack")
 _re_youtube_timestamp = re.compile(r"&t=(\d+)s?")
 _re_soundcloud_timestamp = re.compile(r"#t=(\d+):(\d+)s?")
-_re_twitch_timestamp = re.compile((r"\?t=(\d+)h(\d+)m(\d+)s")
+_re_twitch_timestamp = re.compile(r"\?t=(\d+)h(\d+)m(\d+)s")
 
 
 def parse_timestamps(url, data):

--- a/lavalink/rest_api.py
+++ b/lavalink/rest_api.py
@@ -105,7 +105,7 @@ class LoadResult:
 
     def __init__(self, data):
         self._raw = data
-        for k, v in self._fallback.items():
+        for k, v in self._fallback.items(): # TODO: Check do we have to support Python 2? from the setup files doesn't look like we do
             if k not in data:
                 if k == "exception" and data.get("loadType") != LoadType.LOAD_FAILED:
                     continue

--- a/lavalink/rest_api.py
+++ b/lavalink/rest_api.py
@@ -164,18 +164,7 @@ class Track:
 
     def __hash__(self):
         """Overrides the default implementation"""
-        return hash(
-            tuple(
-                sorted(
-                    [
-                        self.track_identifier,
-                        self.title,
-                        self.author,
-                        self.uri,
-                    ]
-                )
-            )
-        )
+        return hash(tuple(sorted([self.track_identifier, self.title, self.author, self.uri])))
 
 
 class LoadResult:

--- a/lavalink/rest_api.py
+++ b/lavalink/rest_api.py
@@ -107,7 +107,9 @@ class LoadResult:
         self._raw = data
         for k, v in self._fallback.items():
             if k not in data:
-                data.update({k, v})
+                if k == "exception" and data.get("loadType") != LoadType.LOAD_FAILED:
+                    continue
+                data.update({k: v})
 
         self.load_type = LoadType(data["loadType"])
 

--- a/lavalink/rest_api.py
+++ b/lavalink/rest_api.py
@@ -200,7 +200,7 @@ class LoadResult:
                 ):
                     continue
                 elif k == "exception":
-                    v["message"] = v["message"] + "\n{query}\n{response)".format(
+                    v["message"] = v["message"] + "\n{query}\n{response}".format(
                         query="Query: " + data["encodedquery"] if data.get("encodedquery") else "",
                         response=str(self._raw),
                     )

--- a/lavalink/rest_api.py
+++ b/lavalink/rest_api.py
@@ -192,7 +192,6 @@ class LoadResult:
 
     def __init__(self, data):
         self._raw = data
-        # TODO: Check do we have to support Python 2? from the setup files doesn't look like we do
         for (k, v) in self._fallback.items():
             if k not in data:
                 if (

--- a/lavalink/rest_api.py
+++ b/lavalink/rest_api.py
@@ -18,7 +18,7 @@ _re_soundcloud_timestamp = re.compile(r"#t=(\d+):(\d+)s?")
 _re_twitch_timestamp = re.compile(r"\?t=(\d+)h(\d+)m(\d+)s")
 
 
-def parse_timestamps(url, data):
+def parse_timestamps(data):
 
     if data["loadType"] == LoadType.PLAYLIST_LOADED:
         return data["tracks"]
@@ -27,7 +27,7 @@ def parse_timestamps(url, data):
     for track in data["tracks"]:
         start_time = 0
         try:
-            query_url = urlparse(url)
+            query_url = urlparse(data["query"])
             if all([query_url.scheme, query_url.netloc, query_url.path]):
                 url_domain = ".".join(query_url.netloc.split(".")[-2:])
                 if not query_url.netloc:

--- a/lavalink/rest_api.py
+++ b/lavalink/rest_api.py
@@ -35,19 +35,21 @@ def parse_timestamps(data):
     for track in data["tracks"]:
         start_time = 0
         try:
-            if all([query_url.scheme, query_url.netloc, query_url.path]) or any(x in query for x in ["ytsearch:", "scsearch:"]):
+            if all([query_url.scheme, query_url.netloc, query_url.path]) or any(
+                x in query for x in ["ytsearch:", "scsearch:"]
+            ):
                 url_domain = ".".join(query_url.netloc.split(".")[-2:])
                 if not query_url.netloc:
                     url_domain = ".".join(query_url.path.split("/")[0].split(".")[-2:])
                 if (
-                        (url_domain in ["youtube.com", "youtu.be"] or "ytsearch:" in query)
+                    (url_domain in ["youtube.com", "youtu.be"] or "ytsearch:" in query)
                     and any(x in query for x in ["&t=", "?t="])
                     and not all(k in query for k in ["playlist?", "&list="])
                 ):
                     match = re.search(_re_youtube_timestamp, query)
                     if match:
                         start_time = int(match.group(1))
-                elif (url_domain == "soundcloud.com" or "scsearch:" in query)and "#t=" in query:
+                elif (url_domain == "soundcloud.com" or "scsearch:" in query) and "#t=" in query:
                     if "/sets/" not in query or ("/sets/" in query and "?in=" in query):
                         match = re.search(_re_soundcloud_timestamp, query)
                         if match:
@@ -70,14 +72,16 @@ def parse_timestamps(data):
 def reformat_query(query):
     try:
         query_url = urlparse(query)
-        if all([query_url.scheme, query_url.netloc, query_url.path]) or any(x in query for x in ["ytsearch:", "scsearch:"]):
+        if all([query_url.scheme, query_url.netloc, query_url.path]) or any(
+            x in query for x in ["ytsearch:", "scsearch:"]
+        ):
             url_domain = ".".join(query_url.netloc.split(".")[-2:])
             if not query_url.netloc:
                 url_domain = ".".join(query_url.path.split("/")[0].split(".")[-2:])
             if (
-                    (url_domain in ["youtube.com", "youtu.be"] or "ytsearch:" in query)
-                    and any(x in query for x in ["&t=", "?t="])
-                    and not all(k in query for k in ["playlist?", "&list="])
+                (url_domain in ["youtube.com", "youtu.be"] or "ytsearch:" in query)
+                and any(x in query for x in ["&t=", "?t="])
+                and not all(k in query for k in ["playlist?", "&list="])
             ):
                 match = re.search(_re_youtube_timestamp, query)
                 if match:
@@ -94,6 +98,7 @@ def reformat_query(query):
     except Exception:
         pass
     return query
+
 
 class Track:
     """

--- a/lavalink/rest_api.py
+++ b/lavalink/rest_api.py
@@ -151,7 +151,7 @@ class Track:
     def __eq__(self, other):
         """Overrides the default implementation"""
         if isinstance(other, Track):
-            return self.number == other.number
+            return self.track_identifier == other.track_identifier
         return NotImplemented
 
     def __ne__(self, other):
@@ -163,7 +163,21 @@ class Track:
 
     def __hash__(self):
         """Overrides the default implementation"""
-        return hash(tuple(sorted(self.__dict__.items())))
+        return hash(
+            tuple(
+                sorted(
+                    [
+                        self.track_identifier,
+                        self.title,
+                        self.author,
+                        self.length,
+                        self.uri,
+                        self.seekable,
+                        self.is_stream,
+                    ]
+                )
+            )
+        )
 
 
 class LoadResult:

--- a/lavalink/rest_api.py
+++ b/lavalink/rest_api.py
@@ -200,7 +200,7 @@ class LoadResult:
                     and data.get("loadType", LoadType.LOAD_FAILED) != LoadType.LOAD_FAILED
                 ):
                     continue
-                else:
+                elif k == "exception":
                     v["message"] = v["message"] + "\n{query}\n{response)".format(
                         query="Query: " + data["encodedquery"] if data.get("encodedquery") else "",
                         response=str(self._raw),

--- a/lavalink/rest_api.py
+++ b/lavalink/rest_api.py
@@ -93,12 +93,25 @@ class LoadResult:
     tracks : Tuple[Track, ...]
         The tracks that were loaded, if any
     """
+    _fallback = {
+                    "loadType": LoadType.LOAD_FAILED,
+                    "exception": {
+                        "message": "Lavalink api returned an unsupported response.",
+                        "severity": ExceptionSeverity.SUSPICIOUS,
+                    },
+                    "playlistInfo": {},
+                    "tracks": [],
+                }
 
     def __init__(self, data):
         self._raw = data
+        for k, v in self._fallback.items():
+            if k not in data:
+                data.update({k, v})
+
         self.load_type = LoadType(data["loadType"])
 
-        is_playlist = self._raw.get("isPlaylist")
+        is_playlist = self._raw.get("isPlaylist") or self.load_type == LoadType.PLAYLIST_LOADED
         if is_playlist is True:
             self.is_playlist = True
             self.playlist_info = PlaylistInfo(**data["playlistInfo"])

--- a/lavalink/rest_api.py
+++ b/lavalink/rest_api.py
@@ -170,10 +170,7 @@ class Track:
                         self.track_identifier,
                         self.title,
                         self.author,
-                        self.length,
                         self.uri,
-                        self.seekable,
-                        self.is_stream,
                     ]
                 )
             )

--- a/lavalink/rest_api.py
+++ b/lavalink/rest_api.py
@@ -62,6 +62,23 @@ class Track:
         if "youtube" in self.uri and "identifier" in self._info:
             return "https://img.youtube.com/vi/{}/mqdefault.jpg".format(self._info["identifier"])
 
+    def __eq__(self, other):
+        """Overrides the default implementation"""
+        if isinstance(other, Track):
+            return self.number == other.number
+        return NotImplemented
+
+    def __ne__(self, other):
+        """Overrides the default implementation"""
+        x = self.__eq__(other)
+        if x is not NotImplemented:
+            return not x
+        return NotImplemented
+
+    def __hash__(self):
+        """Overrides the default implementation"""
+        return hash(tuple(sorted(self.__dict__.items())))
+
 
 class LoadResult:
     """

--- a/lavalink/rest_api.py
+++ b/lavalink/rest_api.py
@@ -141,6 +141,7 @@ class Track:
         self.title = self._info.get("title")
         self.uri = self._info.get("uri")
         self.start_timestamp = self._info.get("timestamp", 0)
+        self.extras = data.get("extras", {})
 
     @property
     def thumbnail(self):

--- a/lavalink/rest_api.py
+++ b/lavalink/rest_api.py
@@ -142,7 +142,7 @@ class LoadResult:
     _fallback = {
         "loadType": LoadType.LOAD_FAILED,
         "exception": {
-            "message": "Lavalink api returned an unsupported response.",
+            "message": "Lavalink API returned an unsupported response, Please report it.",
             "severity": ExceptionSeverity.SUSPICIOUS,
         },
         "playlistInfo": {},
@@ -156,6 +156,11 @@ class LoadResult:
             if k not in data:
                 if k == "exception" and data.get("loadType") != LoadType.LOAD_FAILED:
                     continue
+                else:
+                    v["message"] = v["message"] + "\n{query}\n{response)".format(
+                        query="Query: " + data["encodedquery"] if data.get("encodedquery") else "",
+                        response=str(self._raw)
+                    )
                 data.update({k: v})
 
         self.load_type = LoadType(data["loadType"])

--- a/lavalink/rest_api.py
+++ b/lavalink/rest_api.py
@@ -1,16 +1,13 @@
 import re
-from typing import Tuple
+from collections import namedtuple
+from typing import Tuple, Union
+from urllib.parse import quote, urlparse
 
 from aiohttp import ClientSession
 from aiohttp.client_exceptions import ServerDisconnectedError
-from collections import namedtuple
 
 from . import log
 from .enums import *
-
-from urllib.parse import quote, urlparse
-
-from typing import Union
 
 __all__ = ["Track", "RESTClient", "PlaylistInfo"]
 
@@ -85,6 +82,8 @@ class Track:
         Title of this track.
     uri : str
         The playback url of this track.
+    start_timestamp: int
+        The track start time in milliseconds as provided by the query.
     """
 
     def __init__(self, data):
@@ -159,7 +158,7 @@ class LoadResult:
                 else:
                     v["message"] = v["message"] + "\n{query}\n{response)".format(
                         query="Query: " + data["encodedquery"] if data.get("encodedquery") else "",
-                        response=str(self._raw)
+                        response=str(self._raw),
                     )
                 data.update({k: v})
 

--- a/lavalink/rest_api.py
+++ b/lavalink/rest_api.py
@@ -13,6 +13,9 @@ __all__ = ["Track", "RESTClient", "PlaylistInfo"]
 
 
 PlaylistInfo = namedtuple("PlaylistInfo", "name selectedTrack")
+_re_youtube_timestamp = re.compile(r"&t=(\d+)s?")
+_re_soundcloud_timestamp = re.compile(r"#t=(\d+):(\d+)s?")
+_re_twitch_timestamp = re.compile((r"\?t=(\d+)h(\d+)m(\d+)s")
 
 
 def parse_timestamps(url, data):
@@ -34,16 +37,16 @@ def parse_timestamps(url, data):
                     and "&t=" in track
                     and not all(k in track for k in ["playlist?", "&list="])
                 ):
-                    match = re.search(r"&t=(\d+)s?", track)
+                    match = re.search(_re_youtube_timestamp, track)
                     if match:
                         start_time = int(match.group(1))
                 elif url_domain == "soundcloud.com" and "#t=" in track:
                     if "/sets/" not in track or ("/sets/" in track and "?in=" in track):
-                        match = re.search(r"#t=(\d+):(\d+)s?", track)
+                        match = re.search(_re_soundcloud_timestamp, track)
                         if match:
                             start_time = (int(match.group(1)) * 60) + int(match.group(2))
                 elif url_domain == "twitch.tv" and "?t=" in track:
-                    match = re.search(r"\?t=(\d+)h(\d+)m(\d+)s", track)
+                    match = re.search(_re_twitch_timestamp, track)
                     if match:
                         start_time = (
                             (int(match.group(1)) * 60 * 60)

--- a/lavalink/rest_api.py
+++ b/lavalink/rest_api.py
@@ -214,7 +214,6 @@ class LoadResult:
         else:
             self.is_playlist = None
             self.playlist_info = None
-        print(self._raw.get("query"))
         _tracks = parse_timestamps(self._raw) if self._raw.get("query") else data["tracks"]
         self.tracks = tuple(Track(t) for t in _tracks)
 

--- a/lavalink/rest_api.py
+++ b/lavalink/rest_api.py
@@ -206,19 +206,19 @@ class LoadResult:
                     )
                 self._raw.update({k: v})
 
-        self.load_type = LoadType(data["loadType"])
+        self.load_type = LoadType(self._raw["loadType"])
 
         is_playlist = self._raw.get("isPlaylist") or self.load_type == LoadType.PLAYLIST_LOADED
         if is_playlist is True:
             self.is_playlist = True
-            self.playlist_info = PlaylistInfo(**data["playlistInfo"])
+            self.playlist_info = PlaylistInfo(**self._raw["playlistInfo"])
         elif is_playlist is False:
             self.is_playlist = False
             self.playlist_info = None
         else:
             self.is_playlist = None
             self.playlist_info = None
-        _tracks = parse_timestamps(self._raw) if self._raw.get("query") else data["tracks"]
+        _tracks = parse_timestamps(self._raw) if self._raw.get("query") else self._raw["tracks"]
         self.tracks = tuple(Track(t) for t in _tracks)
 
     @property

--- a/lavalink/rest_api.py
+++ b/lavalink/rest_api.py
@@ -153,7 +153,10 @@ class LoadResult:
         # TODO: Check do we have to support Python 2? from the setup files doesn't look like we do
         for (k, v) in self._fallback.items():
             if k not in data:
-                if k == "exception" and data.get("loadType") != LoadType.LOAD_FAILED:
+                if (
+                    k == "exception"
+                    and data.get("loadType", LoadType.LOAD_FAILED) != LoadType.LOAD_FAILED
+                ):
                     continue
                 else:
                     v["message"] = v["message"] + "\n{query}\n{response)".format(

--- a/lavalink/rest_api.py
+++ b/lavalink/rest_api.py
@@ -53,9 +53,10 @@ def parse_timestamps(data):
                             + (int(match.group(2)) * 60)
                             + int(match.group(3))
                         )
-        except Exception:
+        except Exception as e:
+            print(e)
             pass
-
+        print("start_time", start_time)
         track["info"]["timestamp"] = start_time * 1000
         new_tracks.append(track)
     return new_tracks

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ packages =
     lavalink
 python_requires = >=3.5.3
 install_requires =
-    websockets>=6.0,<8.0
+    websockets>=6.0,<7.0
 
 [options.extras_require]
 tests =

--- a/tests/test_player_manager.py
+++ b/tests/test_player_manager.py
@@ -54,9 +54,7 @@ async def test_autoconnect(
     state = voice_state_update()
     await node.player_manager.on_socket_response(server)
 
-    assert voice_channel.guild.id not in set(
-        node.player_manager.guild_ids
-    )
+    assert voice_channel.guild.id not in set(node.player_manager.guild_ids)
 
     await node.player_manager.on_socket_response(state)
 


### PR DESCRIPTION
- Adds start timestamp support for Youtube, Soundcloud and Twitch.
- Make Track objects comparable natively.
- Fixes loadType KeyError when Lavalink returns an invalid response (503 for example) This also exposes the query send to the API and response returned into the error message
- Adds playlist metadata for V3 (Before even if it was provided by the API we would ignore it)
- Shuffle now has its own method. so the client needs to manually call it
