### PR TITLE
Add node stats support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -672,3 +672,32 @@ may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
 <http://www.gnu.org/philosophy/why-not-lgpl.html>.
+
+The Red-Lavalink project contains subcomponents in node.py that have a 
+separate copyright notice and license terms. Your use of the source code for 
+these subcomponents is subject to the terms and conditions of the following 
+licenses.
+
+This product bundles methods from https://github.com/PythonistaGuild/Wavelink/
+blob/master/wavelink/stats.py and https://github.com/PythonistaGuild/Wavelink/
+blob/master/wavelink/websocket.py which are available under an MIT license.
+
+Copyright (c) 2019 EvieePy(MysterialPy)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -5,7 +5,7 @@ socket_log = logging.getLogger("red.core.lavalink.socket")
 socket_log.setLevel(logging.INFO)
 
 from .lavalink import *
-from .node import Node, Stats
+from .node import Node, NodeStats, Stats
 from .player_manager import *
 from .enums import NodeState, PlayerState, TrackEndReason, LavalinkEvents
 from .rest_api import Track

--- a/lavalink/node.py
+++ b/lavalink/node.py
@@ -30,7 +30,7 @@ class Stats:
         self.uptime = uptime
 
 
-# Node stats related class bellow and how it is called is originally from:
+# Node stats related class below and how it is called is originally from:
 # https://github.com/PythonistaGuild/Wavelink/blob/master/wavelink/stats.py#L41
 # https://github.com/PythonistaGuild/Wavelink/blob/master/wavelink/websocket.py#L132
 class NodeStats:

--- a/lavalink/node.py
+++ b/lavalink/node.py
@@ -12,10 +12,9 @@ from .enums import *
 from .player_manager import PlayerManager
 from .rest_api import Track
 
-__all__ = ["Stats", "Node", "get_node", "join_voice"]
+__all__ = ["Stats", "Node", "NodeStats", "get_node", "get_nodes_stats", "join_voice"]
 
 _nodes = []  # type: List[Node]
-
 
 PlayerState = namedtuple("PlayerState", "position time")
 MemoryInfo = namedtuple("MemoryInfo", "reservable used free allocated")
@@ -29,6 +28,33 @@ class Stats:
         self.active_players = active_players
         self.cpu_info = CPUInfo(**cpu)
         self.uptime = uptime
+
+
+# Node stats related class bellow and how it is called is originally from:
+# https://github.com/PythonistaGuild/Wavelink/blob/master/wavelink/stats.py#L41
+# https://github.com/PythonistaGuild/Wavelink/blob/master/wavelink/websocket.py#L132
+class NodeStats:
+    def __init__(self, data: dict):
+        self.uptime = data["uptime"]
+
+        self.players = data["players"]
+        self.playing_players = data["playingPlayers"]
+
+        memory = data["memory"]
+        self.memory_free = memory["free"]
+        self.memory_used = memory["used"]
+        self.memory_allocated = memory["allocated"]
+        self.memory_reservable = memory["reservable"]
+
+        cpu = data["cpu"]
+        self.cpu_cores = cpu["cores"]
+        self.system_load = cpu["systemLoad"]
+        self.lavalink_load = cpu["lavalinkLoad"]
+
+        frame_stats = data.get("frameStats", {})
+        self.frames_sent = frame_stats.get("sent", -1)
+        self.frames_nulled = frame_stats.get("nulled", -1)
+        self.frames_deficit = frame_stats.get("deficit", -1)
 
 
 class Node:
@@ -84,6 +110,8 @@ class Node:
         self._state_handlers = []
 
         self.player_manager = PlayerManager(self)
+
+        self.stats = None
 
         if self not in _nodes:
             _nodes.append(self)
@@ -202,6 +230,7 @@ class Node:
                 cpu=data.get("cpu"),
                 uptime=data.get("uptime"),
             )
+            self.stats = NodeStats(data)
             self.event_handler(op, stats, data)
 
     async def _reconnect(self):
@@ -365,6 +394,10 @@ def get_node(guild_id: int, ignore_ready_status: bool = False) -> Node:
         raise IndexError("No nodes found.")
 
     return least_used
+
+
+def get_nodes_stats():
+    return [node.stats for node in _nodes]
 
 
 async def join_voice(guild_id: int, channel_id: int):


### PR DESCRIPTION
This PR adds the possibility to get stats from Lavalink nodes. For now we're using one Lavalink node, but the way to get the stats from the node was missing and I think that's a useful add.

You can fetch them using `lavalink.get_player(guild_id).node.stats` which will returns the stats of the node used on the current guild.
Or also using `lavalink.node.get_nodes_stats()` which will returns a list for all nodes with stats of them inside.