### PR TITLE
Change `websockets` requirement to `>=8.1`

### DIFF
--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -11,4 +11,4 @@ from .enums import NodeState, PlayerState, TrackEndReason, LavalinkEvents
 from .rest_api import Track
 from . import utils
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ packages =
     lavalink
 python_requires = >=3.5.3
 install_requires =
-    websockets>=6.0,<7.0
+    websockets>=8.1
 
 [options.extras_require]
 tests =


### PR DESCRIPTION
And I also bumped the red-lavalink version since we're gonna need to make a release with this change soon™ too.