### PR TITLE
Use version regex instead of importing lavalink to get version in setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = Red-Lavalink
-version = attr: lavalink.__version__
 url = https://github.com/Cog-Creators/Red-Lavalink
 license = GPLv3
 author = tekulvw

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,14 @@
+import os.path
+import re
 from setuptools import setup
 
+root_dir = os.path.abspath(os.path.dirname(__file__))
+version_file = os.path.join(root_dir, "lavalink", "__init__.py")
 
-setup()
+with open(version_file) as fp:
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", fp.read(), re.M)
+    if not version_match:
+      raise RuntimeError("Unable to find version string.")
+    version = version_match.group(1)
+
+setup(version=version)


### PR DESCRIPTION
Currently, setuptools will try to import `lavalink` package to get package's version. When installing Red-Lavalink from source, this may fail because lavalink depends on discord.py package which gets installed *after* setuptools tries to import the package to get version.
This PR makes `setup.py` use a regex to get version from package's `__init__.py` file without actually importing it as recommended as one of techniques for getting a version in Python's docs:
https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version

At one point we were using `try: except ImportError` to avoid lack of d.py from failing the setup (see #47), but it was later removed (see #55) so now I'm adding it back, just in a different way.