### PR TITLE
Add support to Lavalink Filters.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,81 @@
 # Created by .ignore support plugin (hsz.mobi)
+### Linux template
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### Eclipse template
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# PyDev specific (Python IDE for Eclipse)
+*.pydevproject
+
+# CDT-specific (C/C++ Development Tooling)
+.cproject
+
+# CDT- autotools
+.autotools
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific (PHP Development Tools)
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# Tern plugin
+.tern-project
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+# Code Recommenders
+.recommenders/
+
+# Annotation Processing
+.apt_generated/
+.apt_generated_test/
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+.cache-main
+.scala_dependencies
+.worksheet
+
+# Uncomment this line if you wish to ignore the project description file.
+# Typically, this file would be tracked if it contains build/dependency configurations:
+#.project
+
 ### Python template
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -22,6 +99,7 @@ parts/
 sdist/
 var/
 wheels/
+share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
@@ -40,13 +118,17 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
+.nox/
 .coverage
 .coverage.*
 .cache
 nosetests.xml
 coverage.xml
 *.cover
+*.py,cover
 .hypothesis/
+.pytest_cache/
+cover/
 
 # Translations
 *.mo
@@ -54,9 +136,9 @@ coverage.xml
 
 # Django stuff:
 *.log
-.static_storage/
-.media/
 local_settings.py
+db.sqlite3
+db.sqlite3-journal
 
 # Flask stuff:
 instance/
@@ -69,16 +151,34 @@ instance/
 docs/_build/
 
 # PyBuilder
+.pybuilder/
 target/
 
 # Jupyter Notebook
 .ipynb_checkpoints
 
-# pyenv
-.python-version
+# IPython
+profile_default/
+ipython_config.py
 
-# celery beat schedule file
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
 celerybeat-schedule
+celerybeat.pid
 
 # SageMath parsed files
 *.sage.py
@@ -104,22 +204,131 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+### Python template
+# Byte-compiled / optimized / DLL files
+
+# C extensions
+
+# Distribution / packaging
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+
+# Installer logs
+
+# Unit test / coverage reports
+
+# Translations
+
+# Django stuff:
+
+# Flask stuff:
+
+# Scrapy stuff:
+
+# Sphinx documentation
+
+# PyBuilder
+
+# Jupyter Notebook
+
+# IPython
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+
+# Celery stuff
+
+# SageMath parsed files
+
+# Environments
+
+# Spyder project settings
+
+# Rope project settings
+
+# mkdocs documentation
+
+# mypy
+
+# Pyre type checker
+
+# pytype static type analyzer
+
+# Cython debug symbols
+
 ### JetBrains template
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
-.idea
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
 
 # CMake
-cmake-build-debug/
-cmake-build-release/
+cmake-build-*/
 
-# Mongo Explorer plugin:
+# Mongo Explorer plugin
 .idea/**/mongoSettings.xml
 
-## File-based project format:
+# File-based project format
 *.iws
-
-## Plugin-specific files:
 
 # IntelliJ
 out/
@@ -138,3 +347,1038 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Windows template
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+### VisualStudio template
+## Ignore Visual Studio temporary files, build results, and
+## files generated by popular Visual Studio add-ons.
+##
+## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
+
+# User-specific files
+*.rsuser
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# User-specific files (MonoDevelop/Xamarin Studio)
+*.userprefs
+
+# Mono auto generated files
+mono_crash.*
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+[Ww][Ii][Nn]32/
+[Aa][Rr][Mm]/
+[Aa][Rr][Mm]64/
+bld/
+[Bb]in/
+[Oo]bj/
+[Ll]og/
+[Ll]ogs/
+
+# Visual Studio 2015/2017 cache/options directory
+.vs/
+# Uncomment if you have tasks that create the project's static files in wwwroot
+#wwwroot/
+
+# Visual Studio 2017 auto generated files
+Generated\ Files/
+
+# MSTest test Results
+[Tt]est[Rr]esult*/
+[Bb]uild[Ll]og.*
+
+# NUnit
+*.VisualState.xml
+TestResult.xml
+nunit-*.xml
+
+# Build Results of an ATL Project
+[Dd]ebugPS/
+[Rr]eleasePS/
+dlldata.c
+
+# Benchmark Results
+BenchmarkDotNet.Artifacts/
+
+# .NET Core
+project.lock.json
+project.fragment.lock.json
+artifacts/
+
+# ASP.NET Scaffolding
+ScaffoldingReadMe.txt
+
+# StyleCop
+StyleCopReport.xml
+
+# Files built by Visual Studio
+*_i.c
+*_p.c
+*_h.h
+*.ilk
+*.meta
+*.obj
+*.iobj
+*.pch
+*.pdb
+*.ipdb
+*.pgc
+*.pgd
+*.rsp
+*.sbr
+*.tlb
+*.tli
+*.tlh
+*.tmp_proj
+*_wpftmp.csproj
+*.vspscc
+*.vssscc
+.builds
+*.pidb
+*.svclog
+*.scc
+
+# Chutzpah Test files
+_Chutzpah*
+
+# Visual C++ cache files
+ipch/
+*.aps
+*.ncb
+*.opendb
+*.opensdf
+*.sdf
+*.cachefile
+*.VC.db
+*.VC.VC.opendb
+
+# Visual Studio profiler
+*.psess
+*.vsp
+*.vspx
+*.sap
+
+# Visual Studio Trace Files
+*.e2e
+
+# TFS 2012 Local Workspace
+$tf/
+
+# Guidance Automation Toolkit
+*.gpState
+
+# ReSharper is a .NET coding add-in
+_ReSharper*/
+*.[Rr]e[Ss]harper
+*.DotSettings.user
+
+# TeamCity is a build add-in
+_TeamCity*
+
+# DotCover is a Code Coverage Tool
+*.dotCover
+
+# AxoCover is a Code Coverage Tool
+.axoCover/*
+!.axoCover/settings.json
+
+# Coverlet is a free, cross platform Code Coverage Tool
+coverage*.json
+coverage*.xml
+coverage*.info
+
+# Visual Studio code coverage results
+*.coverage
+*.coveragexml
+
+# NCrunch
+_NCrunch_*
+.*crunch*.local.xml
+nCrunchTemp_*
+
+# MightyMoose
+*.mm.*
+AutoTest.Net/
+
+# Web workbench (sass)
+.sass-cache/
+
+# Installshield output folder
+[Ee]xpress/
+
+# DocProject is a documentation generator add-in
+DocProject/buildhelp/
+DocProject/Help/*.HxT
+DocProject/Help/*.HxC
+DocProject/Help/*.hhc
+DocProject/Help/*.hhk
+DocProject/Help/*.hhp
+DocProject/Help/Html2
+DocProject/Help/html
+
+# Click-Once directory
+publish/
+
+# Publish Web Output
+*.[Pp]ublish.xml
+*.azurePubxml
+# Note: Comment the next line if you want to checkin your web deploy settings,
+# but database connection strings (with potential passwords) will be unencrypted
+*.pubxml
+*.publishproj
+
+# Microsoft Azure Web App publish settings. Comment the next line if you want to
+# checkin your Azure Web App publish settings, but sensitive information contained
+# in these scripts will be unencrypted
+PublishScripts/
+
+# NuGet Packages
+*.nupkg
+# NuGet Symbol Packages
+*.snupkg
+# The packages folder can be ignored because of Package Restore
+**/[Pp]ackages/*
+# except build/, which is used as an MSBuild target.
+!**/[Pp]ackages/build/
+# Uncomment if necessary however generally it will be regenerated when needed
+#!**/[Pp]ackages/repositories.config
+# NuGet v3's project.json files produces more ignorable files
+*.nuget.props
+*.nuget.targets
+
+# Microsoft Azure Build Output
+csx/
+*.build.csdef
+
+# Microsoft Azure Emulator
+ecf/
+rcf/
+
+# Windows Store app package directories and files
+AppPackages/
+BundleArtifacts/
+Package.StoreAssociation.xml
+_pkginfo.txt
+*.appx
+*.appxbundle
+*.appxupload
+
+# Visual Studio cache files
+# files ending in .cache can be ignored
+*.[Cc]ache
+# but keep track of directories ending in .cache
+!?*.[Cc]ache/
+
+# Others
+ClientBin/
+~$*
+*.dbmdl
+*.dbproj.schemaview
+*.jfm
+*.pfx
+*.publishsettings
+orleans.codegen.cs
+
+# Including strong name files can present a security risk
+# (https://github.com/github/gitignore/pull/2483#issue-259490424)
+#*.snk
+
+# Since there are multiple workflows, uncomment next line to ignore bower_components
+# (https://github.com/github/gitignore/pull/1529#issuecomment-104372622)
+#bower_components/
+
+# RIA/Silverlight projects
+Generated_Code/
+
+# Backup & report files from converting an old project file
+# to a newer Visual Studio version. Backup files are not needed,
+# because we have git ;-)
+_UpgradeReport_Files/
+Backup*/
+UpgradeLog*.XML
+UpgradeLog*.htm
+ServiceFabricBackup/
+*.rptproj.bak
+
+# SQL Server files
+*.mdf
+*.ldf
+*.ndf
+
+# Business Intelligence projects
+*.rdl.data
+*.bim.layout
+*.bim_*.settings
+*.rptproj.rsuser
+*- [Bb]ackup.rdl
+*- [Bb]ackup ([0-9]).rdl
+*- [Bb]ackup ([0-9][0-9]).rdl
+
+# Microsoft Fakes
+FakesAssemblies/
+
+# GhostDoc plugin setting file
+*.GhostDoc.xml
+
+# Node.js Tools for Visual Studio
+.ntvs_analysis.dat
+node_modules/
+
+# Visual Studio 6 build log
+*.plg
+
+# Visual Studio 6 workspace options file
+*.opt
+
+# Visual Studio 6 auto-generated workspace file (contains which files were open etc.)
+*.vbw
+
+# Visual Studio LightSwitch build output
+**/*.HTMLClient/GeneratedArtifacts
+**/*.DesktopClient/GeneratedArtifacts
+**/*.DesktopClient/ModelManifest.xml
+**/*.Server/GeneratedArtifacts
+**/*.Server/ModelManifest.xml
+_Pvt_Extensions
+
+# Paket dependency manager
+.paket/paket.exe
+paket-files/
+
+# FAKE - F# Make
+.fake/
+
+# CodeRush personal settings
+.cr/personal
+
+# Python Tools for Visual Studio (PTVS)
+*.pyc
+
+# Cake - Uncomment if you are using it
+# tools/**
+# !tools/packages.config
+
+# Tabs Studio
+*.tss
+
+# Telerik's JustMock configuration file
+*.jmconfig
+
+# BizTalk build output
+*.btp.cs
+*.btm.cs
+*.odx.cs
+*.xsd.cs
+
+# OpenCover UI analysis results
+OpenCover/
+
+# Azure Stream Analytics local run output
+ASALocalRun/
+
+# MSBuild Binary and Structured Log
+*.binlog
+
+# NVidia Nsight GPU debugger configuration file
+*.nvuser
+
+# MFractors (Xamarin productivity tool) working folder
+.mfractor/
+
+# Local History for Visual Studio
+.localhistory/
+
+# BeatPulse healthcheck temp database
+healthchecksdb
+
+# Backup folder for Package Reference Convert tool in Visual Studio 2017
+MigrationBackup/
+
+# Ionide (cross platform F# VS Code tools) working folder
+.ionide/
+
+# Fody - auto-generated XML schema
+FodyWeavers.xsd
+
+### Vim template
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+### VirtualEnv template
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+[Bb]in
+[Ii]nclude
+[Ll]ib
+[Ll]ib64
+[Ll]ocal
+[Ss]cripts
+pyvenv.cfg
+pip-selfcheck.json
+
+### VirtualEnv template
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+
+### VisualStudio template
+## Ignore Visual Studio temporary files, build results, and
+## files generated by popular Visual Studio add-ons.
+##
+## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
+
+# User-specific files
+
+# User-specific files (MonoDevelop/Xamarin Studio)
+
+# Mono auto generated files
+
+# Build results
+
+# Visual Studio 2015/2017 cache/options directory
+# Uncomment if you have tasks that create the project's static files in wwwroot
+#wwwroot/
+
+# Visual Studio 2017 auto generated files
+
+# MSTest test Results
+
+# NUnit
+
+# Build Results of an ATL Project
+
+# Benchmark Results
+
+# .NET Core
+
+# ASP.NET Scaffolding
+
+# StyleCop
+
+# Files built by Visual Studio
+
+# Chutzpah Test files
+
+# Visual C++ cache files
+
+# Visual Studio profiler
+
+# Visual Studio Trace Files
+
+# TFS 2012 Local Workspace
+
+# Guidance Automation Toolkit
+
+# ReSharper is a .NET coding add-in
+
+# TeamCity is a build add-in
+
+# DotCover is a Code Coverage Tool
+
+# AxoCover is a Code Coverage Tool
+
+# Coverlet is a free, cross platform Code Coverage Tool
+
+# Visual Studio code coverage results
+
+# NCrunch
+
+# MightyMoose
+
+# Web workbench (sass)
+
+# Installshield output folder
+
+# DocProject is a documentation generator add-in
+
+# Click-Once directory
+
+# Publish Web Output
+# Note: Comment the next line if you want to checkin your web deploy settings,
+# but database connection strings (with potential passwords) will be unencrypted
+
+# Microsoft Azure Web App publish settings. Comment the next line if you want to
+# checkin your Azure Web App publish settings, but sensitive information contained
+# in these scripts will be unencrypted
+
+# NuGet Packages
+# NuGet Symbol Packages
+# The packages folder can be ignored because of Package Restore
+# except build/, which is used as an MSBuild target.
+# Uncomment if necessary however generally it will be regenerated when needed
+#!**/[Pp]ackages/repositories.config
+# NuGet v3's project.json files produces more ignorable files
+
+# Microsoft Azure Build Output
+
+# Microsoft Azure Emulator
+
+# Windows Store app package directories and files
+
+# Visual Studio cache files
+# files ending in .cache can be ignored
+# but keep track of directories ending in .cache
+
+# Others
+
+# Including strong name files can present a security risk
+# (https://github.com/github/gitignore/pull/2483#issue-259490424)
+#*.snk
+
+# Since there are multiple workflows, uncomment next line to ignore bower_components
+# (https://github.com/github/gitignore/pull/1529#issuecomment-104372622)
+#bower_components/
+
+# RIA/Silverlight projects
+
+# Backup & report files from converting an old project file
+# to a newer Visual Studio version. Backup files are not needed,
+# because we have git ;-)
+
+# SQL Server files
+
+# Business Intelligence projects
+
+# Microsoft Fakes
+
+# GhostDoc plugin setting file
+
+# Node.js Tools for Visual Studio
+
+# Visual Studio 6 build log
+
+# Visual Studio 6 workspace options file
+
+# Visual Studio 6 auto-generated workspace file (contains which files were open etc.)
+
+# Visual Studio LightSwitch build output
+
+# Paket dependency manager
+
+# FAKE - F# Make
+
+# CodeRush personal settings
+
+# Python Tools for Visual Studio (PTVS)
+
+# Cake - Uncomment if you are using it
+# tools/**
+# !tools/packages.config
+
+# Tabs Studio
+
+# Telerik's JustMock configuration file
+
+# BizTalk build output
+
+# OpenCover UI analysis results
+
+# Azure Stream Analytics local run output
+
+# MSBuild Binary and Structured Log
+
+# NVidia Nsight GPU debugger configuration file
+
+# MFractors (Xamarin productivity tool) working folder
+
+# Local History for Visual Studio
+
+# BeatPulse healthcheck temp database
+
+# Backup folder for Package Reference Convert tool in Visual Studio 2017
+
+# Ionide (cross platform F# VS Code tools) working folder
+
+# Fody - auto-generated XML schema
+
+### Python template
+# Byte-compiled / optimized / DLL files
+
+# C extensions
+
+# Distribution / packaging
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+
+# Installer logs
+
+# Unit test / coverage reports
+
+# Translations
+
+# Django stuff:
+
+# Flask stuff:
+
+# Scrapy stuff:
+
+# Sphinx documentation
+
+# PyBuilder
+
+# Jupyter Notebook
+
+# IPython
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+
+# Celery stuff
+
+# SageMath parsed files
+
+# Environments
+
+# Spyder project settings
+
+# Rope project settings
+
+# mkdocs documentation
+
+# mypy
+
+# Pyre type checker
+
+# pytype static type analyzer
+
+# Cython debug symbols
+
+### macOS template
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### VirtualEnv template
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+
+# Generated files
+
+# Sensitive or high-churn files
+
+# Gradle
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+
+# Mongo Explorer plugin
+
+# File-based project format
+
+# IntelliJ
+
+# mpeltonen/sbt-idea plugin
+
+# JIRA plugin
+
+# Cursive Clojure plugin
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+
+# Editor-based Rest Client
+
+# Android studio 3.1+ serialized cache file
+
+### Eclipse template
+
+# External tool builders
+
+# Locally stored "Eclipse launch configurations"
+
+# PyDev specific (Python IDE for Eclipse)
+
+# CDT-specific (C/C++ Development Tooling)
+
+# CDT- autotools
+
+# Java annotation processor (APT)
+
+# PDT-specific (PHP Development Tools)
+
+# sbteclipse plugin
+
+# Tern plugin
+
+# TeXlipse plugin
+
+# STS (Spring Tool Suite)
+
+# Code Recommenders
+
+# Annotation Processing
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+
+# Uncomment this line if you wish to ignore the project description file.
+# Typically, this file would be tracked if it contains build/dependency configurations:
+#.project
+
+### Eclipse template
+
+# External tool builders
+
+# Locally stored "Eclipse launch configurations"
+
+# PyDev specific (Python IDE for Eclipse)
+
+# CDT-specific (C/C++ Development Tooling)
+
+# CDT- autotools
+
+# Java annotation processor (APT)
+
+# PDT-specific (PHP Development Tools)
+
+# sbteclipse plugin
+
+# Tern plugin
+
+# TeXlipse plugin
+
+# STS (Spring Tool Suite)
+
+# Code Recommenders
+
+# Annotation Processing
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+
+# Uncomment this line if you wish to ignore the project description file.
+# Typically, this file would be tracked if it contains build/dependency configurations:
+#.project
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+
+# Generated files
+
+# Sensitive or high-churn files
+
+# Gradle
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+
+# Mongo Explorer plugin
+
+# File-based project format
+
+# IntelliJ
+
+# mpeltonen/sbt-idea plugin
+
+# JIRA plugin
+
+# Cursive Clojure plugin
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+
+# Editor-based Rest Client
+
+# Android studio 3.1+ serialized cache file
+
+### VisualStudioCode template
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+# Local History for Visual Studio Code
+.history/
+
+### VisualStudio template
+## Ignore Visual Studio temporary files, build results, and
+## files generated by popular Visual Studio add-ons.
+##
+## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
+
+# User-specific files
+
+# User-specific files (MonoDevelop/Xamarin Studio)
+
+# Mono auto generated files
+
+# Build results
+
+# Visual Studio 2015/2017 cache/options directory
+# Uncomment if you have tasks that create the project's static files in wwwroot
+#wwwroot/
+
+# Visual Studio 2017 auto generated files
+
+# MSTest test Results
+
+# NUnit
+
+# Build Results of an ATL Project
+
+# Benchmark Results
+
+# .NET Core
+
+# ASP.NET Scaffolding
+
+# StyleCop
+
+# Files built by Visual Studio
+
+# Chutzpah Test files
+
+# Visual C++ cache files
+
+# Visual Studio profiler
+
+# Visual Studio Trace Files
+
+# TFS 2012 Local Workspace
+
+# Guidance Automation Toolkit
+
+# ReSharper is a .NET coding add-in
+
+# TeamCity is a build add-in
+
+# DotCover is a Code Coverage Tool
+
+# AxoCover is a Code Coverage Tool
+
+# Coverlet is a free, cross platform Code Coverage Tool
+
+# Visual Studio code coverage results
+
+# NCrunch
+
+# MightyMoose
+
+# Web workbench (sass)
+
+# Installshield output folder
+
+# DocProject is a documentation generator add-in
+
+# Click-Once directory
+
+# Publish Web Output
+# Note: Comment the next line if you want to checkin your web deploy settings,
+# but database connection strings (with potential passwords) will be unencrypted
+
+# Microsoft Azure Web App publish settings. Comment the next line if you want to
+# checkin your Azure Web App publish settings, but sensitive information contained
+# in these scripts will be unencrypted
+
+# NuGet Packages
+# NuGet Symbol Packages
+# The packages folder can be ignored because of Package Restore
+# except build/, which is used as an MSBuild target.
+# Uncomment if necessary however generally it will be regenerated when needed
+#!**/[Pp]ackages/repositories.config
+# NuGet v3's project.json files produces more ignorable files
+
+# Microsoft Azure Build Output
+
+# Microsoft Azure Emulator
+
+# Windows Store app package directories and files
+
+# Visual Studio cache files
+# files ending in .cache can be ignored
+# but keep track of directories ending in .cache
+
+# Others
+
+# Including strong name files can present a security risk
+# (https://github.com/github/gitignore/pull/2483#issue-259490424)
+#*.snk
+
+# Since there are multiple workflows, uncomment next line to ignore bower_components
+# (https://github.com/github/gitignore/pull/1529#issuecomment-104372622)
+#bower_components/
+
+# RIA/Silverlight projects
+
+# Backup & report files from converting an old project file
+# to a newer Visual Studio version. Backup files are not needed,
+# because we have git ;-)
+
+# SQL Server files
+
+# Business Intelligence projects
+
+# Microsoft Fakes
+
+# GhostDoc plugin setting file
+
+# Node.js Tools for Visual Studio
+
+# Visual Studio 6 build log
+
+# Visual Studio 6 workspace options file
+
+# Visual Studio 6 auto-generated workspace file (contains which files were open etc.)
+
+# Visual Studio LightSwitch build output
+
+# Paket dependency manager
+
+# FAKE - F# Make
+
+# CodeRush personal settings
+
+# Python Tools for Visual Studio (PTVS)
+
+# Cake - Uncomment if you are using it
+# tools/**
+# !tools/packages.config
+
+# Tabs Studio
+
+# Telerik's JustMock configuration file
+
+# BizTalk build output
+
+# OpenCover UI analysis results
+
+# Azure Stream Analytics local run output
+
+# MSBuild Binary and Structured Log
+
+# NVidia Nsight GPU debugger configuration file
+
+# MFractors (Xamarin productivity tool) working folder
+
+# Local History for Visual Studio
+
+# BeatPulse healthcheck temp database
+
+# Backup folder for Package Reference Convert tool in Visual Studio 2017
+
+# Ionide (cross platform F# VS Code tools) working folder
+
+# Fody - auto-generated XML schema
+

--- a/.gitignore
+++ b/.gitignore
@@ -1382,3 +1382,535 @@ Temporary Items
 
 # Fody - auto-generated XML schema
 
+### Linux template
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+
+# KDE directory preferences
+
+# Linux trash folder which might appear on any partition or disk
+
+# .nfs files are created when an open file is removed but is still being accessed
+
+### Windows template
+# Windows thumbnail cache files
+
+# Dump file
+
+# Folder config file
+
+# Recycle Bin used on file shares
+
+# Windows Installer files
+
+# Windows shortcuts
+
+### Linux template
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+
+# KDE directory preferences
+
+# Linux trash folder which might appear on any partition or disk
+
+# .nfs files are created when an open file is removed but is still being accessed
+
+### PuTTY template
+# Private key
+*.ppk
+
+### VisualStudioCode template
+
+# Local History for Visual Studio Code
+
+### MicrosoftOffice template
+
+# Word temporary
+~$*.doc*
+
+# Word Auto Backup File
+Backup of *.doc*
+
+# Excel temporary
+~$*.xls*
+
+# Excel Backup File
+*.xlk
+
+# PowerPoint temporary
+~$*.ppt*
+
+# Visio autosave temporary files
+*.~vsd*
+
+### VirtualEnv template
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+
+### Xcode template
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+## Gcc Patch
+/*.gcno
+
+### LibreOffice template
+# LibreOffice locks
+.~lock.*#
+
+### Windows template
+# Windows thumbnail cache files
+
+# Dump file
+
+# Folder config file
+
+# Recycle Bin used on file shares
+
+# Windows Installer files
+
+# Windows shortcuts
+
+### Dropbox template
+# Dropbox settings and caches
+.dropbox
+.dropbox.attr
+.dropbox.cache
+
+### LibreOffice template
+# LibreOffice locks
+
+### Python template
+# Byte-compiled / optimized / DLL files
+
+# C extensions
+
+# Distribution / packaging
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+
+# Installer logs
+
+# Unit test / coverage reports
+
+# Translations
+
+# Django stuff:
+
+# Flask stuff:
+
+# Scrapy stuff:
+
+# Sphinx documentation
+
+# PyBuilder
+
+# Jupyter Notebook
+
+# IPython
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+
+# Celery stuff
+
+# SageMath parsed files
+
+# Environments
+
+# Spyder project settings
+
+# Rope project settings
+
+# mkdocs documentation
+
+# mypy
+
+# Pyre type checker
+
+# pytype static type analyzer
+
+# Cython debug symbols
+
+### Mercurial template
+.hg/
+.hgignore
+.hgsigs
+.hgsub
+.hgsubstate
+.hgtags
+
+### SublimeText template
+# Cache files for Sublime Text
+*.tmlanguage.cache
+*.tmPreferences.cache
+*.stTheme.cache
+
+# Workspace files are user-specific
+*.sublime-workspace
+
+# Project files should be checked into the repository, unless a significant
+# proportion of contributors will probably not be using Sublime Text
+# *.sublime-project
+
+# SFTP configuration file
+sftp-config.json
+sftp-config-alt*.json
+
+# Package control specific files
+Package Control.last-run
+Package Control.ca-list
+Package Control.ca-bundle
+Package Control.system-ca-bundle
+Package Control.cache/
+Package Control.ca-certs/
+Package Control.merged-ca-bundle
+Package Control.user-ca-bundle
+oscrypto-ca-bundle.crt
+bh_unicode_properties.cache
+
+# Sublime-github package stores a github token in this file
+# https://packagecontrol.io/packages/sublime-github
+GitHub.sublime-settings
+
+### Vim template
+# Swap
+
+# Session
+
+# Temporary
+# Auto-generated tag files
+# Persistent undo
+
+### Mercurial template
+
+### Dropbox template
+# Dropbox settings and caches
+
+### macOS template
+# General
+
+# Icon must end with two \r
+
+# Thumbnails
+
+# Files that might appear in the root of a volume
+
+# Directories potentially created on remote AFP share
+
+### Eclipse template
+
+# External tool builders
+
+# Locally stored "Eclipse launch configurations"
+
+# PyDev specific (Python IDE for Eclipse)
+
+# CDT-specific (C/C++ Development Tooling)
+
+# CDT- autotools
+
+# Java annotation processor (APT)
+
+# PDT-specific (PHP Development Tools)
+
+# sbteclipse plugin
+
+# Tern plugin
+
+# TeXlipse plugin
+
+# STS (Spring Tool Suite)
+
+# Code Recommenders
+
+# Annotation Processing
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+
+# Uncomment this line if you wish to ignore the project description file.
+# Typically, this file would be tracked if it contains build/dependency configurations:
+#.project
+
+### Python template
+# Byte-compiled / optimized / DLL files
+
+# C extensions
+
+# Distribution / packaging
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+
+# Installer logs
+
+# Unit test / coverage reports
+
+# Translations
+
+# Django stuff:
+
+# Flask stuff:
+
+# Scrapy stuff:
+
+# Sphinx documentation
+
+# PyBuilder
+
+# Jupyter Notebook
+
+# IPython
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+
+# Celery stuff
+
+# SageMath parsed files
+
+# Environments
+
+# Spyder project settings
+
+# Rope project settings
+
+# mkdocs documentation
+
+# mypy
+
+# Pyre type checker
+
+# pytype static type analyzer
+
+# Cython debug symbols
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+
+# Generated files
+
+# Sensitive or high-churn files
+
+# Gradle
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+
+# Mongo Explorer plugin
+
+# File-based project format
+
+# IntelliJ
+
+# mpeltonen/sbt-idea plugin
+
+# JIRA plugin
+
+# Cursive Clojure plugin
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+
+# Editor-based Rest Client
+
+# Android studio 3.1+ serialized cache file
+
+### Eclipse template
+
+# External tool builders
+
+# Locally stored "Eclipse launch configurations"
+
+# PyDev specific (Python IDE for Eclipse)
+
+# CDT-specific (C/C++ Development Tooling)
+
+# CDT- autotools
+
+# Java annotation processor (APT)
+
+# PDT-specific (PHP Development Tools)
+
+# sbteclipse plugin
+
+# Tern plugin
+
+# TeXlipse plugin
+
+# STS (Spring Tool Suite)
+
+# Code Recommenders
+
+# Annotation Processing
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+
+# Uncomment this line if you wish to ignore the project description file.
+# Typically, this file would be tracked if it contains build/dependency configurations:
+#.project
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+
+# Generated files
+
+# Sensitive or high-churn files
+
+# Gradle
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+
+# Mongo Explorer plugin
+
+# File-based project format
+
+# IntelliJ
+
+# mpeltonen/sbt-idea plugin
+
+# JIRA plugin
+
+# Cursive Clojure plugin
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+
+# Editor-based Rest Client
+
+# Android studio 3.1+ serialized cache file
+
+### macOS template
+# General
+
+# Icon must end with two \r
+
+# Thumbnails
+
+# Files that might appear in the root of a volume
+
+# Directories potentially created on remote AFP share
+
+### TextMate template
+*.tmproj
+*.tmproject
+tmtags
+
+### SublimeText template
+# Cache files for Sublime Text
+
+# Workspace files are user-specific
+
+# Project files should be checked into the repository, unless a significant
+# proportion of contributors will probably not be using Sublime Text
+# *.sublime-project
+
+# SFTP configuration file
+
+# Package control specific files
+
+# Sublime-github package stores a github token in this file
+# https://packagecontrol.io/packages/sublime-github
+
+### TextMate template
+
+### VirtualEnv template
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+
+### Vim template
+# Swap
+
+# Session
+
+# Temporary
+# Auto-generated tag files
+# Persistent undo
+
+### Redis template
+# Ignore redis binary dump (dump.rdb) files
+
+*.rdb
+
+### NetBeans template
+**/nbproject/private/
+**/nbproject/Makefile-*.mk
+**/nbproject/Package-*.bash
+nbbuild/
+nbdist/
+.nb-gradle/
+

--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -1,14 +1,14 @@
-from .log import set_logging_level, log, socket_log, ws_discord_log, ws_ll_log, ws_rll_log
+from .log import log, set_logging_level, socket_log, ws_discord_log, ws_ll_log, ws_rll_log
 
 set_logging_level()
 __version__ = "0.9.0"
 
+from . import utils
+from .enums import LavalinkEvents, NodeState, PlayerState, TrackEndReason
 from .lavalink import *
 from .node import Node, NodeStats, Stats
 from .player_manager import *
-from .enums import NodeState, PlayerState, TrackEndReason, LavalinkEvents
 from .rest_api import Track
-from . import utils
 
 __all__ = [
     "set_logging_level",

--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -1,7 +1,7 @@
 from .log import log, set_logging_level, socket_log, ws_discord_log, ws_ll_log, ws_rll_log
 
 set_logging_level()
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 
 from . import utils
 from .enums import LavalinkEvents, NodeState, PlayerState, TrackEndReason

--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -1,6 +1,7 @@
 from .log import set_logging_level, log, socket_log, ws_discord_log, ws_ll_log, ws_rll_log
 
 set_logging_level()
+__version__ = "0.9.0"
 
 from .lavalink import *
 from .node import Node, NodeStats, Stats
@@ -43,4 +44,3 @@ __all__ = [
     "all_connected_players",
     "active_players",
 ]
-__version__ = "0.8.1"

--- a/lavalink/enums.py
+++ b/lavalink/enums.py
@@ -98,6 +98,9 @@ class LavalinkOutgoingOp(enum.Enum):
     VIBRATO = "filters"
     ROTATION = "filters"
     DISTORTION = "filters"
+    LOWPASS = "filters"
+    CHANNELMIX = "filters"
+
     FILTERS = "filters"
 
 

--- a/lavalink/enums.py
+++ b/lavalink/enums.py
@@ -90,7 +90,15 @@ class LavalinkOutgoingOp(enum.Enum):
     STOP = "stop"
     PAUSE = "pause"
     SEEK = "seek"
-    VOLUME = "volume"
+    VOLUME = "filters"
+    EQ = "filters"
+    KARAOKE = "filters"
+    TIMESCALE = "filters"
+    TREMOLO = "filters"
+    VIBRATO = "filters"
+    ROTATION = "filters"
+    DISTORTION = "filters"
+    FILTERS = "filters"
 
 
 class NodeState(enum.Enum):

--- a/lavalink/enums.py
+++ b/lavalink/enums.py
@@ -91,7 +91,7 @@ class LavalinkOutgoingOp(enum.Enum):
     PAUSE = "pause"
     SEEK = "seek"
     VOLUME = "filters"
-    EQ = "filters"
+    EQUALIZER = "filters"
     KARAOKE = "filters"
     TIMESCALE = "filters"
     TREMOLO = "filters"

--- a/lavalink/filters.py
+++ b/lavalink/filters.py
@@ -82,7 +82,6 @@ class Equalizer(FilterMixin):
     def __init__(self, *, levels: list, name: str = "CustomEqualizer"):
         self.band_count: Final[int] = 15
         self._eq = self._factory(levels)
-        self._index = dict((d["band"], dict(d, index=index)) for (index, d) in enumerate(self._eq))
         self._raw = levels
         self._name = name
         self.off = False
@@ -92,6 +91,10 @@ class Equalizer(FilterMixin):
 
     def __repr__(self):
         return f"<Equalizer: name={self._name}, eq={self._eq}>"
+
+    @property
+    def index(self):
+        return dict((d["band"], dict(d, index=index)) for (index, d) in enumerate(self._eq))
 
     def __eq__(self, other):
         """Overrides the default implementation"""
@@ -273,13 +276,14 @@ class Equalizer(FilterMixin):
     def get_gain(self, band: int) -> float:
         if band < 0 or band >= self.band_count:
             raise IndexError(f"Band {band} does not exist!")
-        return self._index[band].get("gain", 0.0)
+        return self.index[band].get("gain", 0.0)
 
     def visualise(self):
         block = ""
         bands = [str(band + 1).zfill(2) for band in range(self.band_count)]
         bottom = (" " * 8) + " ".join(bands)
-        gains = [1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.0, -0.1, -0.2, -0.25]
+        gains = [x * 0.01 for x in range(-25, 105,  5)]
+        gains.reverse()
 
         for gain in gains:
             prefix = ""

--- a/lavalink/filters.py
+++ b/lavalink/filters.py
@@ -654,3 +654,103 @@ class Distortion(FilterMixin):
         self.tan_scale = 1.0
         self.offset = 0.0
         self.scale = 1.0
+
+
+class LowPass(FilterMixin):
+    def __init__(self, smoothing: float):
+        self._smoothing = smoothing
+
+    def __repr__(self):
+        return f"<LowPass: smoothing={self.smoothing}>"
+
+    @property
+    def smoothing(self) -> float:
+        return self._smoothing
+
+    @smoothing.setter
+    def smoothing(self, v: float):
+        self._smoothing = float(v)
+
+    @classmethod
+    def default(cls) -> LowPass:
+        return cls(smoothing=20.0)
+
+    def get(self) -> Dict[str, float]:
+        return {
+            "smoothing": self.smoothing,
+        }
+
+    def reset(self) -> None:
+        self.smoothing = 20.0
+
+
+class ChannelMix(FilterMixin):
+    def __init__(
+        self,
+        left_to_left: float,
+        left_to_right: float,
+        right_to_left: float,
+        right_to_right: float,
+    ):
+        self.left_to_left = left_to_left
+        self.left_to_right = left_to_right
+        self.right_to_left = right_to_left
+        self.right_to_right = right_to_right
+
+    def __repr__(self):
+        return (
+            f"<ChannelMix: left_to_left={self.left_to_left}, "
+            f"left_to_right={self.left_to_right}, "
+            f"right_to_left={self.right_to_left}, "
+            f"right_to_right={self.right_to_right}>"
+        )
+
+    @property
+    def left_to_left(self) -> float:
+        return self._left_to_left
+
+    @left_to_left.setter
+    def left_to_left(self, v: float):
+        self._left_to_left = float(v)
+
+    @property
+    def left_to_right(self) -> float:
+        return self._left_to_right
+
+    @left_to_right.setter
+    def left_to_right(self, v: float):
+        self._left_to_right = float(v)
+
+    @property
+    def right_to_left(self) -> float:
+        return self._right_to_left
+
+    @right_to_left.setter
+    def right_to_left(self, v: float):
+        self._right_to_left = float(v)
+
+    @property
+    def right_to_right(self) -> float:
+        return self._right_to_right
+
+    @right_to_right.setter
+    def right_to_right(self, v: float):
+        self._right_to_right = float(v)
+
+    @classmethod
+    def default(cls) -> ChannelMix:
+        return cls(left_to_left=1.0, left_to_right=1.0, right_to_left=220.0, right_to_right=100.0)
+
+    def get(self) -> Dict[str, float]:
+        return {
+            "leftToLeft": self.left_to_left,
+            "leftToRight": self.left_to_right,
+            "rightToLeft": self.right_to_left,
+            "rightToRight": self.right_to_right,
+        }
+
+    def reset(self) -> None:
+        self.left_to_left = 1.0
+        self.left_to_right = 0.0
+        self.right_to_left = 0.0
+        self.right_to_right = 1.0

--- a/lavalink/filters.py
+++ b/lavalink/filters.py
@@ -417,8 +417,6 @@ class Rotation(OperationMixin):
 
     @hertz.setter
     def hertz(self, v: float):
-        if not (0.0 < v <= 1.0):
-            raise ValueError(f"Depth must be must be 0.0 < x ≤ 1.0, not {v}")
         self._hertz = float(v)
 
     @classmethod

--- a/lavalink/filters.py
+++ b/lavalink/filters.py
@@ -373,7 +373,6 @@ class Karaoke(FilterMixin):
         self.off = True
 
 
-
 class Timescale(FilterMixin):
     def __init__(self, speed: float, pitch: float, rate: float):
         self.speed = speed
@@ -530,6 +529,7 @@ class Vibrato(FilterMixin):
         self.frequency = 2.0
         self.depth = 0.5  # TODO: Testing: Check: According to LL Code setting this to 0 disableds it .... but 0.5 is also the default.
         self.off = True
+
 
 class Rotation(FilterMixin):
     def __init__(self, hertz: float):

--- a/lavalink/filters.py
+++ b/lavalink/filters.py
@@ -308,7 +308,7 @@ class Karaoke(FilterMixin):
 
     @mono_level.setter
     def mono_level(self, v: float):
-        self._filter_band = float(v)
+        self._mono_level = float(v)
 
     @property
     def filter_band(self) -> float:

--- a/lavalink/filters.py
+++ b/lavalink/filters.py
@@ -316,7 +316,7 @@ class Karaoke(FilterMixin):
 
     @filter_band.setter
     def filter_band(self, v: float):
-        self._level = float(v)
+        self._filter_band = float(v)
 
     @property
     def filter_width(self) -> float:

--- a/lavalink/filters.py
+++ b/lavalink/filters.py
@@ -383,7 +383,7 @@ class Vibrato(FilterMixin):
     @frequency.setter
     def frequency(self, v: float):
         if not (0.0 < v <= 14.0):
-            raise ValueError(f"Frequency must be must be greater than 0, not {v}")
+            raise ValueError(f"Frequency must be must be 0.0 < v <= 14.0, not {v}")
         self._frequency = float(v)
 
     @property

--- a/lavalink/filters.py
+++ b/lavalink/filters.py
@@ -366,11 +366,12 @@ class Karaoke(FilterMixin):
         }
 
     def reset(self) -> None:
-        self.off = True
         self.level = 1.0
         self.mono_level = 1.0
         self.filter_band = 220.0
         self.filter_width = 100.0
+        self.off = True
+
 
 
 class Timescale(FilterMixin):
@@ -425,10 +426,10 @@ class Timescale(FilterMixin):
         }
 
     def reset(self) -> None:
-        self.off = True
         self.speed = 1.0
         self.pitch = 1.0
         self.rate = 1.0
+        self.off = True
 
 
 class Tremolo(FilterMixin):
@@ -476,9 +477,9 @@ class Tremolo(FilterMixin):
         }
 
     def reset(self) -> None:
-        self.off = True
         self.frequency = 2.0
-        self.depth = 0.5  # TODO: Testing:  According to LL Code setting this to 0 disableds it .... but 0.5 is also the default.
+        self.depth = 0.5
+        self.off = True
 
 
 class Vibrato(FilterMixin):
@@ -526,10 +527,9 @@ class Vibrato(FilterMixin):
         }
 
     def reset(self) -> None:
-        self.off = True
         self.frequency = 2.0
         self.depth = 0.5  # TODO: Testing: Check: According to LL Code setting this to 0 disableds it .... but 0.5 is also the default.
-
+        self.off = True
 
 class Rotation(FilterMixin):
     def __init__(self, hertz: float):
@@ -561,8 +561,8 @@ class Rotation(FilterMixin):
         }
 
     def reset(self) -> None:
-        self.off = True
         self.hertz = 0.0
+        self.off = True
 
 
 class Distortion(FilterMixin):
@@ -700,7 +700,6 @@ class Distortion(FilterMixin):
         }
 
     def reset(self) -> None:
-        self.off = True
         self.sin_offset = 0.0
         self.sin_scale = 1.0
         self.cos_offset = 0.0
@@ -709,6 +708,7 @@ class Distortion(FilterMixin):
         self.tan_scale = 1.0
         self.offset = 0.0
         self.scale = 1.0
+        self.off = True
 
 
 class LowPass(FilterMixin):
@@ -741,8 +741,8 @@ class LowPass(FilterMixin):
         }
 
     def reset(self) -> None:
-        self.off = True
         self.smoothing = 20.0
+        self.off = True
 
 
 class ChannelMix(FilterMixin):
@@ -819,8 +819,8 @@ class ChannelMix(FilterMixin):
         }
 
     def reset(self) -> None:
-        self.off = True
         self.left_to_left = 1.0
         self.left_to_right = 0.0
         self.right_to_left = 0.0
         self.right_to_right = 1.0
+        self.off = True

--- a/lavalink/filters.py
+++ b/lavalink/filters.py
@@ -88,7 +88,7 @@ class Equalizer(FilterMixin):
         return self._name
 
     def __repr__(self):
-        return f"<RedLavalink.filters.Equalizer: {self._name}, Raw: {self._eq}>"
+        return f"<Equalizer: name={self._name}, eq={self._eq}>"
 
     def __eq__(self, other):
         """Overrides the default implementation"""
@@ -304,6 +304,9 @@ class Karaoke(FilterMixin):
         self.filter_band = filter_band
         self.filter_width = filter_width
 
+    def __repr__(self):
+        return f"<Karaoke: level={self.level}, mono_level={self.mono_level}, filter_band={self.filter_band}, filter_width={self.filter_width}>"
+
     @property
     def level(self) -> float:
         return self._level
@@ -361,6 +364,9 @@ class Timescale(FilterMixin):
         self.pitch = pitch
         self.rate = rate
 
+    def __repr__(self):
+        return f"<Timescale: speed={self.speed}, pitch={self.pitch}, rate={self.rate}>"
+
     @property
     def speed(self) -> float:
         return self._speed
@@ -407,6 +413,9 @@ class Tremolo(FilterMixin):
         self.frequency = frequency
         self.depth = depth
 
+    def __repr__(self):
+        return f"<Tremolo: frequency={self.frequency}, depth={self.depth}>"
+
     @property
     def frequency(self) -> float:
         return self._frequency
@@ -447,6 +456,9 @@ class Vibrato(FilterMixin):
         self.frequency = frequency
         self.depth = depth
 
+    def __repr__(self):
+        return f"<Vibrato: frequency={self.frequency}, depth={self.depth}>"
+
     @property
     def frequency(self) -> float:
         return self._frequency
@@ -485,6 +497,9 @@ class Vibrato(FilterMixin):
 class Rotation(FilterMixin):
     def __init__(self, hertz: float):
         self.hertz = hertz
+
+    def __repr__(self):
+        return f"<Rotation: hertz={self.hertz}>"
 
     @property
     def hertz(self) -> float:
@@ -527,6 +542,19 @@ class Distortion(FilterMixin):
         self.tan_scale = tan_scale
         self.offset = offset
         self.scale = scale
+
+    def __repr__(self):
+        return (
+            "<Distortion: "
+            f"sin_offset={self.sin_offset}, "
+            f"sin_scale={self.sin_scale}, "
+            f"cos_offset={self.cos_offset}, "
+            f"cos_scale={self.cos_scale}, "
+            f"tan_offset={self.tan_offset}, "
+            f"tan_scale={self.tan_scale}, "
+            f"offset={self.offset}, "
+            f"scale={self.scale}>"
+        )
 
     @property
     def sin_offset(self) -> float:

--- a/lavalink/filters.py
+++ b/lavalink/filters.py
@@ -378,7 +378,7 @@ class Vibrato(OperationMixin):
 
     @frequency.setter
     def frequency(self, v: float):
-        if 0 < v <= 14:
+        if not (0.0 < v <= 14.0):
             raise ValueError(f"Frequency must be must be greater than 0, not {v}")
         self._frequency = float(v)
 

--- a/lavalink/filters.py
+++ b/lavalink/filters.py
@@ -74,7 +74,9 @@ class Equalizer(FilterMixin):
     """
 
     def __init__(self, *, levels: list, name: str = "CustomEqualizer"):
+        self.band_count: Final[int] = 15
         self._eq = self._factory(levels)
+        self._index = dict((d["band"], dict(d, index=index)) for (index, d) in enumerate(self._eq))
         self._raw = levels
 
         self._name = name
@@ -90,12 +92,10 @@ class Equalizer(FilterMixin):
         """The Equalizers friendly name."""
         return self._name
 
-    @staticmethod
-    def _factory(levels: list) -> List[Dict[str, Union[int, float]]]:
+    def _factory(self, levels: list) -> List[Dict[str, Union[int, float]]]:
         _dict = collections.defaultdict(float)
-
-        _dict.update(levels)
-        _dict = [{"band": i, "gain": _dict[i]} for i in range(15)]
+        _dict.update((d.values() for d in levels))
+        _dict = [{"band": i, "gain": _dict[i]} for i in range(self.band_count)]
 
         return _dict
 
@@ -104,8 +104,12 @@ class Equalizer(FilterMixin):
         """Build a custom Equalizer class with the provided levels.
         Parameters
         ------------
-        levels: List[Tuple[int, float]]
-            A list of tuple pairs containing a band int and gain float.
+        levels: List[Dict[str, Union[int, float]]]
+            [
+            {"band": 0, "gain": 0.0},
+            {"band": 1, "gain": 0.0},
+            ...
+            ]
         name: str
             An Optional string to name this Equalizer. Defaults to 'CustomEqualizer'
         """
@@ -117,21 +121,21 @@ class Equalizer(FilterMixin):
         Resets your EQ to Flat.
         """
         levels = [
-            (0, 0.0),
-            (1, 0.0),
-            (2, 0.0),
-            (3, 0.0),
-            (4, 0.0),
-            (5, 0.0),
-            (6, 0.0),
-            (7, 0.0),
-            (8, 0.0),
-            (9, 0.0),
-            (10, 0.0),
-            (11, 0.0),
-            (12, 0.0),
-            (13, 0.0),
-            (14, 0.0),
+            {"band": 0, "gain": 0.0},
+            {"band": 1, "gain": 0.0},
+            {"band": 2, "gain": 0.0},
+            {"band": 3, "gain": 0.0},
+            {"band": 4, "gain": 0.0},
+            {"band": 5, "gain": 0.0},
+            {"band": 6, "gain": 0.0},
+            {"band": 7, "gain": 0.0},
+            {"band": 8, "gain": 0.0},
+            {"band": 9, "gain": 0.0},
+            {"band": 10, "gain": 0.0},
+            {"band": 11, "gain": 0.0},
+            {"band": 12, "gain": 0.0},
+            {"band": 13, "gain": 0.0},
+            {"band": 14, "gain": 0.0},
         ]
 
         return cls(levels=levels, name="Flat")
@@ -143,21 +147,21 @@ class Equalizer(FilterMixin):
         Not suitable for tracks with Deep/Low Bass.
         """
         levels = [
-            (0, -0.075),
-            (1, 0.125),
-            (2, 0.125),
-            (3, 0.1),
-            (4, 0.1),
-            (5, 0.05),
-            (6, 0.075),
-            (7, 0.0),
-            (8, 0.0),
-            (9, 0.0),
-            (10, 0.0),
-            (11, 0.0),
-            (12, 0.125),
-            (13, 0.15),
-            (14, 0.05),
+            {"band": 0, "gain": -0.075},
+            {"band": 1, "gain": 0.125},
+            {"band": 2, "gain": 0.125},
+            {"band": 3, "gain": 0.1},
+            {"band": 4, "gain": 0.1},
+            {"band": 5, "gain": 0.05},
+            {"band": 6, "gain": 0.075},
+            {"band": 7, "gain": 0.0},
+            {"band": 8, "gain": 0.0},
+            {"band": 9, "gain": 0.0},
+            {"band": 10, "gain": 0.0},
+            {"band": 11, "gain": 0.0},
+            {"band": 12, "gain": 0.125},
+            {"band": 13, "gain": 0.15},
+            {"band": 14, "gain": 0.05},
         ]
 
         return cls(levels=levels, name="Boost")
@@ -168,21 +172,21 @@ class Equalizer(FilterMixin):
         Expect clipping on Bassy songs.
         """
         levels = [
-            (0, 0.0),
-            (1, 0.1),
-            (2, 0.1),
-            (3, 0.15),
-            (4, 0.13),
-            (5, 0.1),
-            (6, 0.0),
-            (7, 0.125),
-            (8, 0.175),
-            (9, 0.175),
-            (10, 0.125),
-            (11, 0.125),
-            (12, 0.1),
-            (13, 0.075),
-            (14, 0.0),
+            {"band": 0, "gain": 0.0},
+            {"band": 1, "gain": 0.1},
+            {"band": 2, "gain": 0.1},
+            {"band": 3, "gain": 0.15},
+            {"band": 4, "gain": 0.13},
+            {"band": 5, "gain": 0.1},
+            {"band": 6, "gain": 0.0},
+            {"band": 7, "gain": 0.125},
+            {"band": 8, "gain": 0.175},
+            {"band": 9, "gain": 0.175},
+            {"band": 10, "gain": 0.125},
+            {"band": 11, "gain": 0.125},
+            {"band": 12, "gain": 0.1},
+            {"band": 13, "gain": 0.075},
+            {"band": 14, "gain": 0.0},
         ]
 
         return cls(levels=levels, name="Metal")
@@ -194,20 +198,21 @@ class Equalizer(FilterMixin):
         Could also be used as a Bass Cutoff.
         """
         levels = [
-            (0, -0.25),
-            (1, -0.25),
-            (2, -0.125),
-            (3, 0.0),
-            (4, 0.25),
-            (5, 0.25),
-            (6, 0.0),
-            (7, -0.25),
-            (8, -0.25),
-            (9, 0.0),
-            (10, 0.0),
-            (11, 0.5),
-            (12, 0.25),
-            (13, -0.025),
+            {"band": 0, "gain": -0.25},
+            {"band": 1, "gain": -0.25},
+            {"band": 2, "gain": -0.125},
+            {"band": 3, "gain": 0.0},
+            {"band": 4, "gain": 0.25},
+            {"band": 5, "gain": 0.25},
+            {"band": 6, "gain": 0.0},
+            {"band": 7, "gain": -0.25},
+            {"band": 8, "gain": -0.25},
+            {"band": 9, "gain": 0.0},
+            {"band": 10, "gain": 0.0},
+            {"band": 11, "gain": 0.5},
+            {"band": 12, "gain": 0.25},
+            {"band": 13, "gain": -0.025},
+            {"band": 14, "gain": 0.0},
         ]
 
         return cls(levels=levels, name="Piano")
@@ -224,6 +229,46 @@ class Equalizer(FilterMixin):
         self._eq = eq._eq
         self._name = eq._name
         self._raw = eq._raw
+
+    def set_gain(self, band: int, gain: float) -> None:
+        if band < 0 or band >= self.band_count:
+            raise IndexError(f"Band {band} does not exist!")
+
+        gain = float(min(max(gain, -0.25), 1.0))
+        band = next((index for (index, d) in enumerate(self._eq) if d["band"] == band), None)
+        self._eq[band]["gain"] = gain
+
+    def get_gain(self, band: int) -> float:
+        if band < 0 or band >= self.band_count:
+            raise IndexError(f"Band {band} does not exist!")
+        return self._index[band].get("gain", 0.0)
+
+    def visualise(self):
+        block = ""
+        bands = [str(band + 1).zfill(2) for band in range(self.band_count)]
+        bottom = (" " * 8) + " ".join(bands)
+        gains = [1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.0, -0.1, -0.2, -0.25]
+
+        for gain in gains:
+            prefix = ""
+            if gain > 0:
+                prefix = "+"
+            elif gain == 0:
+                prefix = " "
+
+            block += f"{prefix}{gain:.2f} | "
+
+            for value in self._eq:
+                cur_gain = value.get("gain", 0.0)
+                if cur_gain >= gain:
+                    block += "[] "
+                else:
+                    block += "   "
+
+            block += "\n"
+
+        block += bottom
+        return block
 
 
 class Karaoke(FilterMixin):

--- a/lavalink/filters.py
+++ b/lavalink/filters.py
@@ -53,6 +53,9 @@ class Volume(FilterMixin):
     def get(self) -> float:
         return self.value
 
+    def __repr__(self):
+        return str(self.value)
+
 
 # Implementation taken from https://github.com/PythonistaGuild/Wavelink/blob/master/wavelink/eqs.py
 # TODO: MERGE: Add reference to MIT License from Wavelink

--- a/lavalink/filters.py
+++ b/lavalink/filters.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import collections
-from typing import Dict, List, Union
+from typing import Dict, Final, List, Union
 
 
 class FilterMixin:
@@ -93,6 +93,19 @@ class Equalizer(FilterMixin):
         return self._name
 
     def _factory(self, levels: list) -> List[Dict[str, Union[int, float]]]:
+
+        if isinstance(levels[0], dict):
+            pass
+        elif isinstance(levels[0], (int, float)):
+            levels = [
+                dict(zip(["band", "gain"], values))
+                for values in list(zip(list(range(self.band_count)), levels))
+            ]
+        elif isinstance(levels[0], tuple):
+            levels = [dict(zip(["band", "gain"], values)) for values in levels]
+        else:
+            raise TypeError("Equalizer levels should be a list of dictionaries.")
+
         _dict = collections.defaultdict(float)
         _dict.update((d.values() for d in levels))
         _dict = [{"band": i, "gain": _dict[i]} for i in range(self.band_count)]

--- a/lavalink/filters.py
+++ b/lavalink/filters.py
@@ -90,6 +90,16 @@ class Equalizer(FilterMixin):
     def __repr__(self):
         return f"<RedLavalink.filters.Equalizer: {self._name}, Raw: {self._eq}>"
 
+    def __eq__(self, other):
+        """Overrides the default implementation"""
+        if isinstance(other, Equalizer):
+            return (
+                self.__dict__.keys() == other.__dict__.keys()
+                and self._eq == other._eq
+                and self.name == other.name
+            )
+        return NotImplemented
+
     @property
     def name(self) -> str:
         """The Equalizers friendly name."""

--- a/lavalink/filters.py
+++ b/lavalink/filters.py
@@ -1,0 +1,544 @@
+from __future__ import annotations
+
+import collections
+import operator
+from typing import Dict, List, Union
+
+
+class Volume:
+    def __init__(self, value: float):
+        self.value = value
+
+    def __float__(self):
+        return self.value
+
+    @property
+    def value(self) -> float:
+        return self._value
+
+    @value.setter
+    def value(self, v: float):
+        if v < 0:
+            raise ValueError(f"Volume must be must be greater than or equals to zero, not {v}")
+        self._value = float(v)
+
+    @classmethod
+    def default(cls) -> Volume:
+        return cls(value=1.0)
+
+    def increase(self, by: float = 5.0) -> None:
+        self.value += by
+
+    def decrease(self, by: float = 5.0) -> None:
+        self.value -= by
+
+    def reset(self) -> None:
+        self.value = 1.0
+
+    def get(self) -> float:
+        return self.value
+
+
+# Implementation taken from https://github.com/PythonistaGuild/Wavelink/blob/master/wavelink/eqs.py
+# TODO: MERGE: Add reference to MIT License from Wavelink
+# Theres literally 0 reason to reimplement this specially since we will be moving over to Wavelink in the near future.
+class Equalizer:
+    """Class representing a usable equalizer.
+    Parameters
+    ------------
+    levels: List[Tuple[int, float]]
+        A list of tuple pairs containing a band int and gain float.
+    name: str
+        An Optional string to name this Equalizer. Defaults to 'CustomEqualizer'
+    Attributes
+    ------------
+    eq: list
+        A list of {'band': int, 'gain': float}
+    raw: list
+        A list of tuple pairs containing a band int and gain float.
+    """
+
+    def __init__(self, *, levels: list, name: str = "CustomEqualizer"):
+        self._eq = self._factory(levels)
+        self._raw = levels
+
+        self._name = name
+
+    def __str__(self):
+        return self._name
+
+    def __repr__(self):
+        return f"<RedLavalink.filters.Equalizer: {self._name}, Raw: {self._eq}>"
+
+    @property
+    def name(self) -> str:
+        """The Equalizers friendly name."""
+        return self._name
+
+    @staticmethod
+    def _factory(levels: list) -> List[Dict[str, Union[int, float]]]:
+        _dict = collections.defaultdict(float)
+
+        _dict.update(levels)
+        _dict = [{"band": i, "gain": _dict[i]} for i in range(15)]
+
+        return _dict
+
+    @classmethod
+    def build(cls, *, levels: list, name: str = "CustomEqualizer") -> Equalizer:
+        """Build a custom Equalizer class with the provided levels.
+        Parameters
+        ------------
+        levels: List[Tuple[int, float]]
+            A list of tuple pairs containing a band int and gain float.
+        name: str
+            An Optional string to name this Equalizer. Defaults to 'CustomEqualizer'
+        """
+        return cls(levels=levels, name=name)
+
+    @classmethod
+    def flat(cls) -> Equalizer:
+        """Flat Equalizer.
+        Resets your EQ to Flat.
+        """
+        levels = [
+            (0, 0.0),
+            (1, 0.0),
+            (2, 0.0),
+            (3, 0.0),
+            (4, 0.0),
+            (5, 0.0),
+            (6, 0.0),
+            (7, 0.0),
+            (8, 0.0),
+            (9, 0.0),
+            (10, 0.0),
+            (11, 0.0),
+            (12, 0.0),
+            (13, 0.0),
+            (14, 0.0),
+        ]
+
+        return cls(levels=levels, name="Flat")
+
+    @classmethod
+    def boost(cls) -> Equalizer:
+        """Boost Equalizer.
+        This equalizer emphasizes Punchy Bass and Crisp Mid-High tones.
+        Not suitable for tracks with Deep/Low Bass.
+        """
+        levels = [
+            (0, -0.075),
+            (1, 0.125),
+            (2, 0.125),
+            (3, 0.1),
+            (4, 0.1),
+            (5, 0.05),
+            (6, 0.075),
+            (7, 0.0),
+            (8, 0.0),
+            (9, 0.0),
+            (10, 0.0),
+            (11, 0.0),
+            (12, 0.125),
+            (13, 0.15),
+            (14, 0.05),
+        ]
+
+        return cls(levels=levels, name="Boost")
+
+    @classmethod
+    def metal(cls) -> Equalizer:
+        """Experimental Metal/Rock Equalizer.
+        Expect clipping on Bassy songs.
+        """
+        levels = [
+            (0, 0.0),
+            (1, 0.1),
+            (2, 0.1),
+            (3, 0.15),
+            (4, 0.13),
+            (5, 0.1),
+            (6, 0.0),
+            (7, 0.125),
+            (8, 0.175),
+            (9, 0.175),
+            (10, 0.125),
+            (11, 0.125),
+            (12, 0.1),
+            (13, 0.075),
+            (14, 0.0),
+        ]
+
+        return cls(levels=levels, name="Metal")
+
+    @classmethod
+    def piano(cls) -> Equalizer:
+        """Piano Equalizer.
+        Suitable for Piano tracks, or tacks with an emphasis on Female Vocals.
+        Could also be used as a Bass Cutoff.
+        """
+        levels = [
+            (0, -0.25),
+            (1, -0.25),
+            (2, -0.125),
+            (3, 0.0),
+            (4, 0.25),
+            (5, 0.25),
+            (6, 0.0),
+            (7, -0.25),
+            (8, -0.25),
+            (9, 0.0),
+            (10, 0.0),
+            (11, 0.5),
+            (12, 0.25),
+            (13, -0.025),
+        ]
+
+        return cls(levels=levels, name="Piano")
+
+    @classmethod
+    def default(cls) -> Equalizer:
+        return cls.flat()
+
+    def get(self) -> List[Dict[str, Union[int, float]]]:
+        return self._eq
+
+    def reset(self) -> None:
+        eq = Equalizer.flat()
+        self._eq = eq._eq
+        self._name = eq._name
+        self._raw = eq._raw
+
+
+class Karaoke:
+    def __init__(self, level: float, mono_level: float, filter_band: float, filter_width: float):
+        self.level = level
+        self.mono_level = mono_level
+        self.filter_band = filter_band
+        self.filter_width = filter_width
+
+    @property
+    def level(self) -> float:
+        return self._level
+
+    @level.setter
+    def level(self, v: float):
+        self._level = float(v)
+
+    @property
+    def mono_level(self) -> float:
+        return self._mono_level
+
+    @mono_level.setter
+    def mono_level(self, v: float):
+        self._filter_band = float(v)
+
+    @property
+    def filter_band(self) -> float:
+        return self._filter_band
+
+    @filter_band.setter
+    def filter_band(self, v: float):
+        self._level = float(v)
+
+    @property
+    def filter_width(self) -> float:
+        return self._filter_width
+
+    @filter_width.setter
+    def filter_width(self, v: float):
+        self._filter_width = float(v)
+
+    @classmethod
+    def default(cls) -> Karaoke:
+        return cls(level=1.0, mono_level=1.0, filter_band=220.0, filter_width=100.0)
+
+    def get(self) -> Dict[str, float]:
+        return {
+            "level": self.level,
+            "monoLevel": self.mono_level,
+            "filterBand": self.filter_band,
+            "filterWidth": self.filter_width,
+        }
+
+    def reset(self) -> None:
+        self.level = 1.0
+        self.mono_level = 1.0
+        self.filter_band = 220.0
+        self.filter_width = 100.0
+
+
+class Timescale:
+    def __init__(self, speed: float, pitch: float, rate: float):
+        self.speed = speed
+        self.pitch = pitch
+        self.rate = rate
+
+    @property
+    def speed(self) -> float:
+        return self._speed
+
+    @speed.setter
+    def speed(self, v: float):
+        self._speed = float(v)
+
+    @property
+    def pitch(self) -> float:
+        return self._pitch
+
+    @pitch.setter
+    def pitch(self, v: float):
+        self._pitch = float(v)
+
+    @property
+    def rate(self) -> float:
+        return self._rate
+
+    @rate.setter
+    def rate(self, v: float):
+        self._rate = float(v)
+
+    @classmethod
+    def default(cls) -> Timescale:
+        return cls(speed=1.0, pitch=1.0, rate=1.0)
+
+    def get(self) -> Dict[str, float]:
+        return {
+            "speed": self.speed,
+            "pitch": self.pitch,
+            "rate": self.rate,
+        }
+
+    def reset(self) -> None:
+        self.speed = 1.0
+        self.pitch = 1.0
+        self.rate = 1.0
+
+
+class Tremolo:
+    def __init__(self, frequency: float, depth: float):
+        self.frequency = frequency
+        self.depth = depth
+
+    @property
+    def frequency(self) -> float:
+        return self._frequency
+
+    @frequency.setter
+    def frequency(self, v: float):
+        if v <= 0:
+            raise ValueError(f"Frequency must be must be greater than 0, not {v}")
+        self._frequency = float(v)
+
+    @property
+    def depth(self) -> float:
+        return self._depth
+
+    @depth.setter
+    def depth(self, v: float):
+        if not (0.0 < v <= 1.0):
+            raise ValueError(f"Depth must be must be 0.0 < x ≤ 1.0, not {v}")
+        self._depth = float(v)
+
+    @classmethod
+    def default(cls) -> Tremolo:
+        return cls(frequency=2.0, depth=0.5)
+
+    def get(self) -> Dict[str, float]:
+        return {
+            "frequency": self.frequency,
+            "depth": self.depth,
+        }
+
+    def reset(self) -> None:
+        self.frequency = 2.0
+        self.depth = 0.5  # TODO: Testing:  According to LL Code setting this to 0 disableds it .... but 0.5 is also the default.
+
+
+class Vibrato:
+    def __init__(self, frequency: float, depth: float):
+        self.frequency = frequency
+        self.depth = depth
+
+    @property
+    def frequency(self) -> float:
+        return self._frequency
+
+    @frequency.setter
+    def frequency(self, v: float):
+        if 0 < v <= 14:
+            raise ValueError(f"Frequency must be must be greater than 0, not {v}")
+        self._frequency = float(v)
+
+    @property
+    def depth(self) -> float:
+        return self._depth
+
+    @depth.setter
+    def depth(self, v: float):
+        if not (0.0 < v <= 1.0):
+            raise ValueError(f"Depth must be must be 0.0 < x ≤ 1.0, not {v}")
+        self._depth = float(v)
+
+    @classmethod
+    def default(cls) -> Vibrato:
+        return cls(frequency=2.0, depth=0.5)
+
+    def get(self) -> Dict[str, float]:
+        return {
+            "frequency": self.frequency,
+            "depth": self.depth,
+        }
+
+    def reset(self) -> None:
+        self.frequency = 2.0
+        self.depth = 0.5  # TODO: Testing: Check: According to LL Code setting this to 0 disableds it .... but 0.5 is also the default.
+
+
+class Rotation:
+    def __init__(self, hertz: float):
+        self.hertz = hertz
+
+    @property
+    def hertz(self) -> float:
+        return self._hertz
+
+    @hertz.setter
+    def hertz(self, v: float):
+        if not (0.0 < v <= 1.0):
+            raise ValueError(f"Depth must be must be 0.0 < x ≤ 1.0, not {v}")
+        self._hertz = float(v)
+
+    @classmethod
+    def default(cls) -> Rotation:
+        return cls(hertz=0.0)
+
+    def get(self) -> Dict[str, float]:
+        return {
+            "rotationHz": self.hertz,
+        }
+
+    def reset(self) -> None:
+        self.hertz = 0.0
+
+
+class Distortion:
+    def __init__(
+        self,
+        sin_offset: float,
+        sin_scale: float,
+        cos_offset: float,
+        cos_scale: float,
+        tan_offset: float,
+        tan_scale: float,
+        offset: float,
+        scale: float,
+    ):
+        self.sin_offset = sin_offset
+        self.sin_scale = sin_scale
+        self.cos_offset = cos_offset
+        self.cos_scale = cos_scale
+        self.tan_offset = tan_offset
+        self.tan_scale = tan_scale
+        self.offset = offset
+        self.scale = scale
+
+    @property
+    def sin_offset(self) -> float:
+        return self._sin_offset
+
+    @sin_offset.setter
+    def sin_offset(self, v: float):
+        self._sin_offset = float(v)
+
+    @property
+    def sin_scale(self) -> float:
+        return self._sin_scale
+
+    @sin_scale.setter
+    def sin_scale(self, v: float):
+        self._sin_scale = float(v)
+
+    @property
+    def cos_offset(self) -> float:
+        return self._cos_offset
+
+    @cos_offset.setter
+    def cos_offset(self, v: float):
+        self._cos_offset = float(v)
+
+    @property
+    def cos_scale(self) -> float:
+        return self._cos_scale
+
+    @cos_scale.setter
+    def cos_scale(self, v: float):
+        self._cos_scale = float(v)
+
+    @property
+    def tan_offset(self) -> float:
+        return self._tan_offset
+
+    @tan_offset.setter
+    def tan_offset(self, v: float):
+        self._tan_offset = float(v)
+
+    @property
+    def tan_scale(self) -> float:
+        return self._tan_scale
+
+    @tan_scale.setter
+    def tan_scale(self, v: float):
+        self._tan_scale = float(v)
+
+    @property
+    def offset(self) -> float:
+        return self._offset
+
+    @offset.setter
+    def offset(self, v: float):
+        self._offset = float(v)
+
+    @property
+    def scale(self) -> float:
+        return self._scale
+
+    @scale.setter
+    def scale(self, v: float):
+        self._scale = float(v)
+
+    @classmethod
+    def default(cls) -> Distortion:
+        return cls(
+            sin_offset=0.0,
+            sin_scale=1.0,
+            cos_offset=0.0,
+            cos_scale=1.0,
+            tan_offset=0.0,
+            tan_scale=1.0,
+            offset=0.0,
+            scale=1.0,
+        )
+
+    def get(self) -> Dict[str, float]:
+        return {
+            "sinOffset": self.sin_offset,
+            "sinScale": self.sin_scale,
+            "cosOffset": self.cos_offset,
+            "cosScale": self.cos_scale,
+            "tanOffset": self.tan_offset,
+            "tanScale": self.tan_scale,
+            "offset": self.offset,
+            "scale": self.scale,
+        }
+
+    def reset(self) -> None:
+        self.sin_offset = 0.0
+        self.sin_scale = 1.0
+        self.cos_offset = 0.0
+        self.cos_scale = 1.0
+        self.tan_offset = 0.0
+        self.tan_scale = 1.0
+        self.offset = 0.0
+        self.scale = 1.0

--- a/lavalink/filters.py
+++ b/lavalink/filters.py
@@ -739,7 +739,7 @@ class ChannelMix(FilterMixin):
 
     @classmethod
     def default(cls) -> ChannelMix:
-        return cls(left_to_left=1.0, left_to_right=1.0, right_to_left=220.0, right_to_right=100.0)
+        return cls(left_to_left=1.0, left_to_right=0.0, right_to_left=0.0, right_to_right=1.0)
 
     def get(self) -> Dict[str, float]:
         return {

--- a/lavalink/filters.py
+++ b/lavalink/filters.py
@@ -1,11 +1,22 @@
 from __future__ import annotations
 
 import collections
-import operator
 from typing import Dict, List, Union
 
 
-class Volume:
+class OperationMixin:
+    def __eq__(self, other):
+        """Overrides the default implementation"""
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return NotImplemented
+
+    def __hash__(self):
+        """Overrides the default implementation"""
+        return hash(tuple(sorted(self.__dict__.items())))
+
+
+class Volume(OperationMixin):
     def __init__(self, value: float):
         self.value = value
 
@@ -42,7 +53,7 @@ class Volume:
 # Implementation taken from https://github.com/PythonistaGuild/Wavelink/blob/master/wavelink/eqs.py
 # TODO: MERGE: Add reference to MIT License from Wavelink
 # Theres literally 0 reason to reimplement this specially since we will be moving over to Wavelink in the near future.
-class Equalizer:
+class Equalizer(OperationMixin):
     """Class representing a usable equalizer.
     Parameters
     ------------
@@ -211,7 +222,7 @@ class Equalizer:
         self._raw = eq._raw
 
 
-class Karaoke:
+class Karaoke(OperationMixin):
     def __init__(self, level: float, mono_level: float, filter_band: float, filter_width: float):
         self.level = level
         self.mono_level = mono_level
@@ -269,7 +280,7 @@ class Karaoke:
         self.filter_width = 100.0
 
 
-class Timescale:
+class Timescale(OperationMixin):
     def __init__(self, speed: float, pitch: float, rate: float):
         self.speed = speed
         self.pitch = pitch
@@ -316,7 +327,7 @@ class Timescale:
         self.rate = 1.0
 
 
-class Tremolo:
+class Tremolo(OperationMixin):
     def __init__(self, frequency: float, depth: float):
         self.frequency = frequency
         self.depth = depth
@@ -356,7 +367,7 @@ class Tremolo:
         self.depth = 0.5  # TODO: Testing:  According to LL Code setting this to 0 disableds it .... but 0.5 is also the default.
 
 
-class Vibrato:
+class Vibrato(OperationMixin):
     def __init__(self, frequency: float, depth: float):
         self.frequency = frequency
         self.depth = depth
@@ -396,7 +407,7 @@ class Vibrato:
         self.depth = 0.5  # TODO: Testing: Check: According to LL Code setting this to 0 disableds it .... but 0.5 is also the default.
 
 
-class Rotation:
+class Rotation(OperationMixin):
     def __init__(self, hertz: float):
         self.hertz = hertz
 
@@ -423,7 +434,7 @@ class Rotation:
         self.hertz = 0.0
 
 
-class Distortion:
+class Distortion(OperationMixin):
     def __init__(
         self,
         sin_offset: float,

--- a/lavalink/filters.py
+++ b/lavalink/filters.py
@@ -5,6 +5,8 @@ from typing import Dict, Final, List, Union
 
 
 class FilterMixin:
+    off: bool = True
+
     def __eq__(self, other):
         """Overrides the default implementation"""
         if isinstance(other, self.__class__):
@@ -17,12 +19,13 @@ class FilterMixin:
 
     @property
     def changed(self) -> bool:
-        return self != self.__class__.default()
+        return self.off is False
 
 
 class Volume(FilterMixin):
     def __init__(self, value: float):
         self.value = value
+        self.off = False
 
     def __float__(self):
         return self.value
@@ -81,8 +84,8 @@ class Equalizer(FilterMixin):
         self._eq = self._factory(levels)
         self._index = dict((d["band"], dict(d, index=index)) for (index, d) in enumerate(self._eq))
         self._raw = levels
-
         self._name = name
+        self.off = False
 
     def __str__(self):
         return self._name
@@ -248,9 +251,12 @@ class Equalizer(FilterMixin):
         return cls.flat()
 
     def get(self) -> List[Dict[str, Union[int, float]]]:
+        if self.off:
+            return []
         return self._eq
 
     def reset(self) -> None:
+        self.off = True
         eq = Equalizer.flat()
         self._eq = eq._eq
         self._name = eq._name
@@ -314,6 +320,7 @@ class Karaoke(FilterMixin):
     @level.setter
     def level(self, v: float):
         self._level = float(v)
+        self.off = False
 
     @property
     def mono_level(self) -> float:
@@ -322,6 +329,7 @@ class Karaoke(FilterMixin):
     @mono_level.setter
     def mono_level(self, v: float):
         self._mono_level = float(v)
+        self.off = False
 
     @property
     def filter_band(self) -> float:
@@ -330,6 +338,7 @@ class Karaoke(FilterMixin):
     @filter_band.setter
     def filter_band(self, v: float):
         self._filter_band = float(v)
+        self.off = False
 
     @property
     def filter_width(self) -> float:
@@ -338,12 +347,17 @@ class Karaoke(FilterMixin):
     @filter_width.setter
     def filter_width(self, v: float):
         self._filter_width = float(v)
+        self.off = False
 
     @classmethod
     def default(cls) -> Karaoke:
-        return cls(level=1.0, mono_level=1.0, filter_band=220.0, filter_width=100.0)
+        c = cls(level=1.0, mono_level=1.0, filter_band=220.0, filter_width=100.0)
+        c.off = True
+        return c
 
     def get(self) -> Dict[str, float]:
+        if self.off:
+            return {}
         return {
             "level": self.level,
             "monoLevel": self.mono_level,
@@ -352,6 +366,7 @@ class Karaoke(FilterMixin):
         }
 
     def reset(self) -> None:
+        self.off = True
         self.level = 1.0
         self.mono_level = 1.0
         self.filter_band = 220.0
@@ -374,6 +389,7 @@ class Timescale(FilterMixin):
     @speed.setter
     def speed(self, v: float):
         self._speed = float(v)
+        self.off = False
 
     @property
     def pitch(self) -> float:
@@ -382,6 +398,7 @@ class Timescale(FilterMixin):
     @pitch.setter
     def pitch(self, v: float):
         self._pitch = float(v)
+        self.off = False
 
     @property
     def rate(self) -> float:
@@ -390,12 +407,17 @@ class Timescale(FilterMixin):
     @rate.setter
     def rate(self, v: float):
         self._rate = float(v)
+        self.off = False
 
     @classmethod
     def default(cls) -> Timescale:
-        return cls(speed=1.0, pitch=1.0, rate=1.0)
+        c = cls(speed=1.0, pitch=1.0, rate=1.0)
+        c.off = True
+        return c
 
     def get(self) -> Dict[str, float]:
+        if self.off:
+            return {}
         return {
             "speed": self.speed,
             "pitch": self.pitch,
@@ -403,6 +425,7 @@ class Timescale(FilterMixin):
         }
 
     def reset(self) -> None:
+        self.off = True
         self.speed = 1.0
         self.pitch = 1.0
         self.rate = 1.0
@@ -425,6 +448,7 @@ class Tremolo(FilterMixin):
         if v <= 0:
             raise ValueError(f"Frequency must be must be greater than 0, not {v}")
         self._frequency = float(v)
+        self.off = False
 
     @property
     def depth(self) -> float:
@@ -435,18 +459,24 @@ class Tremolo(FilterMixin):
         if not (0.0 < v <= 1.0):
             raise ValueError(f"Depth must be must be 0.0 < x ≤ 1.0, not {v}")
         self._depth = float(v)
+        self.off = False
 
     @classmethod
     def default(cls) -> Tremolo:
-        return cls(frequency=2.0, depth=0.5)
+        c = cls(frequency=2.0, depth=0.5)
+        c.off = True
+        return c
 
     def get(self) -> Dict[str, float]:
+        if self.off:
+            return {}
         return {
             "frequency": self.frequency,
             "depth": self.depth,
         }
 
     def reset(self) -> None:
+        self.off = True
         self.frequency = 2.0
         self.depth = 0.5  # TODO: Testing:  According to LL Code setting this to 0 disableds it .... but 0.5 is also the default.
 
@@ -468,6 +498,7 @@ class Vibrato(FilterMixin):
         if not (0.0 < v <= 14.0):
             raise ValueError(f"Frequency must be must be 0.0 < v <= 14.0, not {v}")
         self._frequency = float(v)
+        self.off = False
 
     @property
     def depth(self) -> float:
@@ -478,18 +509,24 @@ class Vibrato(FilterMixin):
         if not (0.0 < v <= 1.0):
             raise ValueError(f"Depth must be must be 0.0 < x ≤ 1.0, not {v}")
         self._depth = float(v)
+        self.off = False
 
     @classmethod
     def default(cls) -> Vibrato:
-        return cls(frequency=2.0, depth=0.5)
+        c = cls(frequency=2.0, depth=0.5)
+        c.off = True
+        return c
 
     def get(self) -> Dict[str, float]:
+        if self.off:
+            return {}
         return {
             "frequency": self.frequency,
             "depth": self.depth,
         }
 
     def reset(self) -> None:
+        self.off = True
         self.frequency = 2.0
         self.depth = 0.5  # TODO: Testing: Check: According to LL Code setting this to 0 disableds it .... but 0.5 is also the default.
 
@@ -508,17 +545,23 @@ class Rotation(FilterMixin):
     @hertz.setter
     def hertz(self, v: float):
         self._hertz = float(v)
+        self.off = False
 
     @classmethod
     def default(cls) -> Rotation:
-        return cls(hertz=0.0)
+        c = cls(hertz=0.0)
+        c.off = True
+        return c
 
     def get(self) -> Dict[str, float]:
+        if self.off:
+            return {}
         return {
             "rotationHz": self.hertz,
         }
 
     def reset(self) -> None:
+        self.off = True
         self.hertz = 0.0
 
 
@@ -563,6 +606,7 @@ class Distortion(FilterMixin):
     @sin_offset.setter
     def sin_offset(self, v: float):
         self._sin_offset = float(v)
+        self.off = False
 
     @property
     def sin_scale(self) -> float:
@@ -579,6 +623,7 @@ class Distortion(FilterMixin):
     @cos_offset.setter
     def cos_offset(self, v: float):
         self._cos_offset = float(v)
+        self.off = False
 
     @property
     def cos_scale(self) -> float:
@@ -587,6 +632,7 @@ class Distortion(FilterMixin):
     @cos_scale.setter
     def cos_scale(self, v: float):
         self._cos_scale = float(v)
+        self.off = False
 
     @property
     def tan_offset(self) -> float:
@@ -595,6 +641,7 @@ class Distortion(FilterMixin):
     @tan_offset.setter
     def tan_offset(self, v: float):
         self._tan_offset = float(v)
+        self.off = False
 
     @property
     def tan_scale(self) -> float:
@@ -603,6 +650,7 @@ class Distortion(FilterMixin):
     @tan_scale.setter
     def tan_scale(self, v: float):
         self._tan_scale = float(v)
+        self.off = False
 
     @property
     def offset(self) -> float:
@@ -611,6 +659,7 @@ class Distortion(FilterMixin):
     @offset.setter
     def offset(self, v: float):
         self._offset = float(v)
+        self.off = False
 
     @property
     def scale(self) -> float:
@@ -619,10 +668,11 @@ class Distortion(FilterMixin):
     @scale.setter
     def scale(self, v: float):
         self._scale = float(v)
+        self.off = False
 
     @classmethod
     def default(cls) -> Distortion:
-        return cls(
+        c = cls(
             sin_offset=0.0,
             sin_scale=1.0,
             cos_offset=0.0,
@@ -632,8 +682,12 @@ class Distortion(FilterMixin):
             offset=0.0,
             scale=1.0,
         )
+        c.off = True
+        return c
 
     def get(self) -> Dict[str, float]:
+        if self.off:
+            return {}
         return {
             "sinOffset": self.sin_offset,
             "sinScale": self.sin_scale,
@@ -646,6 +700,7 @@ class Distortion(FilterMixin):
         }
 
     def reset(self) -> None:
+        self.off = True
         self.sin_offset = 0.0
         self.sin_scale = 1.0
         self.cos_offset = 0.0
@@ -670,17 +725,23 @@ class LowPass(FilterMixin):
     @smoothing.setter
     def smoothing(self, v: float):
         self._smoothing = float(v)
+        self.off = False
 
     @classmethod
     def default(cls) -> LowPass:
-        return cls(smoothing=20.0)
+        c = cls(smoothing=20.0)
+        c.off = True
+        return c
 
     def get(self) -> Dict[str, float]:
+        if self.off:
+            return {}
         return {
             "smoothing": self.smoothing,
         }
 
     def reset(self) -> None:
+        self.off = True
         self.smoothing = 20.0
 
 
@@ -712,6 +773,7 @@ class ChannelMix(FilterMixin):
     @left_to_left.setter
     def left_to_left(self, v: float):
         self._left_to_left = float(v)
+        self.off = False
 
     @property
     def left_to_right(self) -> float:
@@ -720,6 +782,7 @@ class ChannelMix(FilterMixin):
     @left_to_right.setter
     def left_to_right(self, v: float):
         self._left_to_right = float(v)
+        self.off = False
 
     @property
     def right_to_left(self) -> float:
@@ -728,6 +791,7 @@ class ChannelMix(FilterMixin):
     @right_to_left.setter
     def right_to_left(self, v: float):
         self._right_to_left = float(v)
+        self.off = False
 
     @property
     def right_to_right(self) -> float:
@@ -736,12 +800,17 @@ class ChannelMix(FilterMixin):
     @right_to_right.setter
     def right_to_right(self, v: float):
         self._right_to_right = float(v)
+        self.off = False
 
     @classmethod
     def default(cls) -> ChannelMix:
-        return cls(left_to_left=1.0, left_to_right=0.0, right_to_left=0.0, right_to_right=1.0)
+        c = cls(left_to_left=1.0, left_to_right=0.0, right_to_left=0.0, right_to_right=1.0)
+        c.off = True
+        return c
 
     def get(self) -> Dict[str, float]:
+        if self.off:
+            return {}
         return {
             "leftToLeft": self.left_to_left,
             "leftToRight": self.left_to_right,
@@ -750,6 +819,7 @@ class ChannelMix(FilterMixin):
         }
 
     def reset(self) -> None:
+        self.off = True
         self.left_to_left = 1.0
         self.left_to_right = 0.0
         self.right_to_left = 0.0

--- a/lavalink/filters.py
+++ b/lavalink/filters.py
@@ -4,7 +4,7 @@ import collections
 from typing import Dict, List, Union
 
 
-class OperationMixin:
+class FilterMixin:
     def __eq__(self, other):
         """Overrides the default implementation"""
         if isinstance(other, self.__class__):
@@ -15,8 +15,12 @@ class OperationMixin:
         """Overrides the default implementation"""
         return hash(tuple(sorted(self.__dict__.items())))
 
+    @property
+    def changed(self) -> bool:
+        return self != self.__class__.default()
 
-class Volume(OperationMixin):
+
+class Volume(FilterMixin):
     def __init__(self, value: float):
         self.value = value
 
@@ -53,7 +57,7 @@ class Volume(OperationMixin):
 # Implementation taken from https://github.com/PythonistaGuild/Wavelink/blob/master/wavelink/eqs.py
 # TODO: MERGE: Add reference to MIT License from Wavelink
 # Theres literally 0 reason to reimplement this specially since we will be moving over to Wavelink in the near future.
-class Equalizer(OperationMixin):
+class Equalizer(FilterMixin):
     """Class representing a usable equalizer.
     Parameters
     ------------
@@ -222,7 +226,7 @@ class Equalizer(OperationMixin):
         self._raw = eq._raw
 
 
-class Karaoke(OperationMixin):
+class Karaoke(FilterMixin):
     def __init__(self, level: float, mono_level: float, filter_band: float, filter_width: float):
         self.level = level
         self.mono_level = mono_level
@@ -280,7 +284,7 @@ class Karaoke(OperationMixin):
         self.filter_width = 100.0
 
 
-class Timescale(OperationMixin):
+class Timescale(FilterMixin):
     def __init__(self, speed: float, pitch: float, rate: float):
         self.speed = speed
         self.pitch = pitch
@@ -327,7 +331,7 @@ class Timescale(OperationMixin):
         self.rate = 1.0
 
 
-class Tremolo(OperationMixin):
+class Tremolo(FilterMixin):
     def __init__(self, frequency: float, depth: float):
         self.frequency = frequency
         self.depth = depth
@@ -367,7 +371,7 @@ class Tremolo(OperationMixin):
         self.depth = 0.5  # TODO: Testing:  According to LL Code setting this to 0 disableds it .... but 0.5 is also the default.
 
 
-class Vibrato(OperationMixin):
+class Vibrato(FilterMixin):
     def __init__(self, frequency: float, depth: float):
         self.frequency = frequency
         self.depth = depth
@@ -407,7 +411,7 @@ class Vibrato(OperationMixin):
         self.depth = 0.5  # TODO: Testing: Check: According to LL Code setting this to 0 disableds it .... but 0.5 is also the default.
 
 
-class Rotation(OperationMixin):
+class Rotation(FilterMixin):
     def __init__(self, hertz: float):
         self.hertz = hertz
 
@@ -432,7 +436,7 @@ class Rotation(OperationMixin):
         self.hertz = 0.0
 
 
-class Distortion(OperationMixin):
+class Distortion(FilterMixin):
     def __init__(
         self,
         sin_offset: float,

--- a/lavalink/lavalink.py
+++ b/lavalink/lavalink.py
@@ -196,8 +196,12 @@ def _get_event_args(data: enums.LavalinkEvents, raw_data: dict):
     if data == enums.LavalinkEvents.TRACK_END:
         extra = enums.TrackEndReason(raw_data.get("reason"))
     elif data == enums.LavalinkEvents.TRACK_EXCEPTION:
-        log.critical(str(raw_data))  # TODO: Testing: Remove me
-        extra = raw_data.get("message")
+        extra = {
+            "message": raw_data.get("exception", {}).get(
+                "message", "Something went wrong when decoding the track!"
+            ),
+            "cause": raw_data.get("exception", {}).get("cause", "Unhandled Exception!"),
+        }
     elif data == enums.LavalinkEvents.TRACK_STUCK:
         extra = raw_data.get("thresholdMs")
     elif data == enums.LavalinkEvents.TRACK_START:

--- a/lavalink/lavalink.py
+++ b/lavalink/lavalink.py
@@ -196,7 +196,7 @@ def _get_event_args(data: enums.LavalinkEvents, raw_data: dict):
     if data == enums.LavalinkEvents.TRACK_END:
         extra = enums.TrackEndReason(raw_data.get("reason"))
     elif data == enums.LavalinkEvents.TRACK_EXCEPTION:
-        log.critical(str(raw_data))  # TODO: Remove me
+        log.critical(str(raw_data))  # TODO: Testing: Remove me
         extra = raw_data.get("message")
     elif data == enums.LavalinkEvents.TRACK_STUCK:
         extra = raw_data.get("thresholdMs")

--- a/lavalink/lavalink.py
+++ b/lavalink/lavalink.py
@@ -196,7 +196,8 @@ def _get_event_args(data: enums.LavalinkEvents, raw_data: dict):
     if data == enums.LavalinkEvents.TRACK_END:
         extra = enums.TrackEndReason(raw_data.get("reason"))
     elif data == enums.LavalinkEvents.TRACK_EXCEPTION:
-        extra = raw_data.get("error")
+        log.critical(str(raw_data))  # TODO: Remove me
+        extra = raw_data.get("message")
     elif data == enums.LavalinkEvents.TRACK_STUCK:
         extra = raw_data.get("thresholdMs")
     elif data == enums.LavalinkEvents.TRACK_START:

--- a/lavalink/node.py
+++ b/lavalink/node.py
@@ -20,7 +20,7 @@ __all__ = ["Stats", "Node", "NodeStats", "get_node", "get_nodes_stats", "join_vo
 
 _nodes: List[Node] = []
 
-PlayerState = namedtuple("PlayerState", "position time")
+PlayerState = namedtuple("PlayerState", "position time connected")
 MemoryInfo = namedtuple("MemoryInfo", "reservable used free allocated")
 CPUInfo = namedtuple("CPUInfo", "cores systemLoad lavalinkLoad")
 
@@ -367,7 +367,8 @@ class Node:
                 self.event_handler(op, event, data)
         elif op == LavalinkIncomingOp.PLAYER_UPDATE:
             state = data.get("state", {})
-            state = PlayerState(position=state.get("position", 0), time=state.get("time", 0))
+            ws_ll_log.critical(str(state))  # TODO: Remove me
+            state = PlayerState(position=state.get("position", 0), time=state.get("time", 0), connected=state.get("connected", False))
             self.event_handler(op, state, data)
         elif op == LavalinkIncomingOp.STATS:
             stats = Stats(

--- a/lavalink/node.py
+++ b/lavalink/node.py
@@ -563,10 +563,46 @@ class Node:
             {"op": LavalinkOutgoingOp.PAUSE.value, "guildId": str(guild_id), "pause": paused}
         )
 
+    async def filters(
+        self,
+        *,
+        guild_id: int,
+        volume: Volume = None,
+        equalizer: Equalizer = None,
+        karaoke: Karaoke = None,
+        timescale: Timescale = None,
+        tremolo: Tremolo = None,
+        vibrato: Vibrato = None,
+        rotation: Rotation = None,
+        distortion: Distortion = None,
+    ):
+        op = {
+            "op": LavalinkOutgoingOp.FILTERS.value,
+            "guildId": str(guild_id),
+        }
+        if volume:
+            op["volume"] = volume.get()
+        if equalizer:
+            op["equalizer"] = equalizer.get()
+        if karaoke:
+            op["karaoke"] = karaoke.get()
+        if timescale:
+            op["timescale"] = timescale.get()
+        if tremolo:
+            op["tremolo"] = tremolo.get()
+        if vibrato:
+            op["vibrato"] = vibrato.get()
+        if rotation:
+            op["rotation"] = rotation.get()
+        if distortion:
+            op["distortion"] = distortion.get()
+
+        await self.send(op)
+
     async def volume(self, guild_id: int, volume: Volume):
         await self.send(
             {
-                "op": LavalinkOutgoingOp.VOLUME.value,
+                "op": LavalinkOutgoingOp.FILTERS.value,
                 "guildId": str(guild_id),
                 "volume": volume.get(),
             }

--- a/lavalink/node.py
+++ b/lavalink/node.py
@@ -1,19 +1,31 @@
 from __future__ import annotations
+
 import asyncio
 import contextlib
 import secrets
 import string
+import typing
 from collections import namedtuple
 from typing import Awaitable, List, Optional, cast
 
 import aiohttp
-import typing
 from discord.backoff import ExponentialBackoff
 from discord.ext.commands import Bot
 
 from . import __version__, ws_discord_log, ws_ll_log
 from .enums import *
-from .filters import Distortion, Equalizer, Karaoke, Rotation, Timescale, Tremolo, Vibrato, Volume
+from .filters import (
+    ChannelMix,
+    Distortion,
+    Equalizer,
+    Karaoke,
+    LowPass,
+    Rotation,
+    Timescale,
+    Tremolo,
+    Vibrato,
+    Volume,
+)
 from .player_manager import PlayerManager
 from .rest_api import Track
 
@@ -574,6 +586,8 @@ class Node:
         vibrato: Vibrato = None,
         rotation: Rotation = None,
         distortion: Distortion = None,
+        low_pass: LowPass = None,
+        channel_mix: ChannelMix = None,
     ):
         op = {
             "op": LavalinkOutgoingOp.FILTERS.value,
@@ -595,6 +609,10 @@ class Node:
             op["rotation"] = rotation.get()
         if distortion:
             op["distortion"] = distortion.get()
+        if low_pass:
+            op["lowPass"] = low_pass.get()
+        if channel_mix:
+            op["channelMix"] = channel_mix.get()
 
         await self.send(op)
 
@@ -667,6 +685,24 @@ class Node:
                 "op": LavalinkOutgoingOp.DISTORTION.value,
                 "guildId": str(guild_id),
                 "distortion": distortion.get(),
+            }
+        )
+
+    async def low_pass(self, guild_id: int, low_pass: LowPass):
+        await self.send(
+            {
+                "op": LavalinkOutgoingOp.LOWPASS.value,
+                "guildId": str(guild_id),
+                "lowPass": low_pass.get(),
+            }
+        )
+
+    async def channel_mix(self, guild_id: int, channel_mix: ChannelMix):
+        await self.send(
+            {
+                "op": LavalinkOutgoingOp.CHANNELMIX.value,
+                "guildId": str(guild_id),
+                "channelMix": channel_mix.get(),
             }
         )
 

--- a/lavalink/node.py
+++ b/lavalink/node.py
@@ -598,25 +598,25 @@ class Node:
             "op": LavalinkOutgoingOp.FILTERS.value,
             "guildId": str(guild_id),
         }
-        if volume:
+        if volume and volume.changed:
             op["volume"] = volume.get()
-        if equalizer:
+        if equalizer and equalizer.changed:
             op["equalizer"] = equalizer.get()
-        if karaoke:
+        if karaoke and karaoke.changed:
             op["karaoke"] = karaoke.get()
-        if timescale:
+        if timescale and timescale.changed:
             op["timescale"] = timescale.get()
-        if tremolo:
+        if tremolo and tremolo.changed:
             op["tremolo"] = tremolo.get()
-        if vibrato:
+        if vibrato and vibrato.changed:
             op["vibrato"] = vibrato.get()
-        if rotation:
+        if rotation and rotation.changed:
             op["rotation"] = rotation.get()
-        if distortion:
+        if distortion and distortion.changed:
             op["distortion"] = distortion.get()
-        if low_pass:
+        if low_pass and low_pass.changed:
             op["lowPass"] = low_pass.get()
-        if channel_mix:
+        if channel_mix and channel_mix.changed:
             op["channelMix"] = channel_mix.get()
 
         await self.send(op)

--- a/lavalink/node.py
+++ b/lavalink/node.py
@@ -375,7 +375,6 @@ class Node:
                 self.event_handler(op, event, data)
         elif op == LavalinkIncomingOp.PLAYER_UPDATE:
             state = data.get("state", {})
-            ws_ll_log.critical(str(state))  # TODO: Testing: Remove me
             state = PlayerState(
                 position=state.get("position", 0),
                 time=state.get("time", 0),

--- a/lavalink/node.py
+++ b/lavalink/node.py
@@ -12,6 +12,11 @@ import aiohttp
 from discord.backoff import ExponentialBackoff
 from discord.ext.commands import Bot
 
+try:
+    from redbot import json
+except ImportError:
+    import json
+
 from . import __version__, ws_discord_log, ws_ll_log
 from .enums import *
 from .filters import (
@@ -182,7 +187,7 @@ class Node:
 
         self._ws = None
         self._listener_task = None
-        self.session = aiohttp.ClientSession()
+        self.session = aiohttp.ClientSession(json_serialize=json.dumps)
 
         self._queue: List = []
 
@@ -352,7 +357,7 @@ class Node:
                     ws_ll_log.info("[NODE] | Listener closing: %s", msg.extra)
                     break
             elif msg.type == aiohttp.WSMsgType.TEXT:
-                data = msg.json()
+                data = msg.json(loads=json.loads)
                 try:
                     op = LavalinkIncomingOp(data.get("op"))
                 except ValueError:

--- a/lavalink/node.py
+++ b/lavalink/node.py
@@ -569,7 +569,7 @@ class Node:
         start: int = 0,
         pause: bool = False,
     ):
-        # await self.send({"op": LavalinkOutgoingOp.STOP.value, "guildId": str(guild_id)})
+        await self.send({"op": LavalinkOutgoingOp.STOP.value, "guildId": str(guild_id)})
         await self.no_stop_play(
             guild_id=guild_id, track=track, replace=replace, start=start, pause=pause
         )

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -373,13 +373,13 @@ class Player(RESTClient):
             await self.node.filters(
                 guild_id=self.channel.guild.id,
                 volume=self.volume,
-                equalizer=equalizer or self.equalizer if self.equalizer.changed else None,
-                karaoke=karaoke or self.karaoke if self.karaoke.changed else None,
-                timescale=timescale or self.timescale if self.timescale.changed else None,
-                tremolo=tremolo or self.tremolo if self.timescale.changed else None,
-                vibrato=vibrato or self.vibrato if self.vibrato.changed else None,
-                rotation=rotation or self.rotation if self.rotation.changed else None,
-                distortion=distortion or self.distortion if self.distortion.changed else None,
+                equalizer=equalizer or (self.equalizer if self.equalizer.changed else None),
+                karaoke=karaoke or (self.karaoke if self.karaoke.changed else None),
+                timescale=timescale or (self.timescale if self.timescale.changed else None),
+                tremolo=tremolo or (self.tremolo if self.timescale.changed else None),
+                vibrato=vibrato or (self.vibrato if self.vibrato.changed else None),
+                rotation=rotation or (self.rotation if self.rotation.changed else None),
+                distortion=distortion or (self.distortion if self.distortion.changed else None),
             )
         if volume:
             self._volume = volume

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -87,7 +87,15 @@ class Player(RESTClient):
             f"playing={self.is_playing}, paused={self.paused}, volume={self.volume}, "
             f"queue_size={len(self.queue)}, current={self.current!r}, "
             f"position={self.position}, "
-            f"length={self.current.length if self.current else 0}, node={self.node!r}>"
+            f"length={self.current.length if self.current else 0}, "
+            f"equalizer={self.equalizer!r}, "
+            f"karaoke={self.karaoke!r}, "
+            f"timescale={self.timescale!r}, "
+            f"tremolo={self.tremolo!r}, "
+            f"vibrato={self.vibrato!r}, "
+            f"rotation={self.rotation!r}, "
+            f"distortion={self.distortion!r}, "
+            f"node={self.node!r}>"
         )
 
     @property
@@ -509,13 +517,13 @@ class Player(RESTClient):
             else:
                 self._is_playing = False
                 log.debug(
-                    f"Player position changed but player isn't connected. (Ignoring position update), %r", self
+                    f"Player position changed but player isn't connected. (Ignoring position update), %r",
+                    self,
                 )
-                self.position = state.position
-
                 return
         log.debug("Updated player position for player: %r - %ds.", self, state.position // 1000)
-        self.position = state.position
+        self._last_update = time.time_ns() // 1_000_000
+        self._position = state.position
         self.connected = state.connected
 
     # Play commands
@@ -819,6 +827,6 @@ class PlayerManager:
                 player.state.name,
             )
             return
-        guild_id = player.channel.guild.id
+        guild_id = player.guild.id
         if guild_id in self._player_dict:
             del self._player_dict[guild_id]

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -370,14 +370,6 @@ class Player(RESTClient):
                 distortion=distortion,
             )
         else:
-            equalizer = (self.equalizer if self.equalizer.changed else None,)
-            karaoke = (self.karaoke if self.karaoke.changed else None,)
-            timescale = (self.timescale if self.timescale.changed else None,)
-            tremolo = (self.tremolo if self.timescale.changed else None,)
-            vibrato = (self.vibrato if self.vibrato.changed else None,)
-            rotation = (self.rotation if self.rotation.changed else None,)
-            distortion = (self.distortion if self.distortion.changed else None,)
-
             await self.node.filters(
                 guild_id=self.channel.guild.id,
                 volume=self.volume,

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -384,7 +384,7 @@ class Player(RESTClient):
         if reset_not_set:
             await self.node.filters(
                 guild_id=self.channel.guild.id,
-                volume=volume,
+                volume=volume or self.volume,
                 equalizer=equalizer,
                 karaoke=karaoke,
                 timescale=timescale,
@@ -411,35 +411,36 @@ class Player(RESTClient):
                 or (self.channel_mix if self.channel_mix.changed else None),
             )
         changed = False
-        if volume:
+        if volume and volume.changed:
             self._volume = volume
-        if equalizer:
             changed = True
+        if equalizer and equalizer.changed:
             self._equalizer = equalizer
-        if karaoke:
             changed = True
+        if karaoke and karaoke.changed:
             self._karaoke = karaoke
-        if timescale:
             changed = True
+        if timescale and timescale.changed:
             self._timescale = timescale
-        if tremolo:
             changed = True
+        if tremolo and tremolo.changed:
             self._tremolo = tremolo
-        if vibrato:
             changed = True
+        if vibrato and vibrato.changed:
             self._vibrato = vibrato
-        if rotation:
             changed = True
+        if rotation and rotation.changed:
             self._rotation = rotation
-        if distortion:
             changed = True
+        if distortion and distortion.changed:
             self._distortion = distortion
-        if low_pass:
             changed = True
+        if low_pass and low_pass.changed:
             self._low_pass = low_pass
-        if channel_mix:
             changed = True
+        if channel_mix and channel_mix.changed:
             self._channel_mix = channel_mix
+            changed = True
 
         self._effect_enabled = changed
         await self.seek(self.position, with_filter=True)

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -54,7 +54,7 @@ class Player(RESTClient):
         self.shuffle_bumped = True
         self._is_autoplaying = False
         self._auto_play_sent = False
-        self._volume = 100
+        self._volume = 1.0
         self.state = PlayerState.CREATED
         self.connected_at = None
         self._connected = False
@@ -99,7 +99,7 @@ class Player(RESTClient):
         return self._paused
 
     @property
-    def volume(self) -> int:
+    def volume(self) -> float:
         """
         The current volume.
         """
@@ -395,16 +395,16 @@ class Player(RESTClient):
         self._paused = pause
         await self.node.pause(self.guild.id, pause)
 
-    async def set_volume(self, volume: int):
+    async def set_volume(self, volume: float):
         """
         Sets the volume of Lavalink.
 
         Parameters
         ----------
-        volume : int
-            Between 0 and 150
+        volume : float
+            Greater and 0
         """
-        self._volume = max(min(volume, 150), 0)
+        self._volume = max(volume, 0.0)
         await self.node.volume(self.guild.id, self.volume)
 
     async def seek(self, position: int):

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -605,7 +605,7 @@ class Player(RESTClient):
         position : int
             Between 0 and track length.
         """
-        if self.current.seekable:
+        if self.current and self.current.seekable:
             position = max(min(position, self.current.length), 0)
             await self.node.seek(self.guild.id, position)
 

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -320,7 +320,7 @@ class Player(RESTClient):
                 equalizer=equalizer or (self.equalizer if self.equalizer.changed else None),
                 karaoke=karaoke or (self.karaoke if self.karaoke.changed else None),
                 timescale=timescale or (self.timescale if self.timescale.changed else None),
-                tremolo=tremolo or (self.tremolo if self.timescale.changed else None),
+                tremolo=tremolo or (self.tremolo if self.tremolo.changed else None),
                 vibrato=vibrato or (self.vibrato if self.vibrato.changed else None),
                 rotation=rotation or (self.rotation if self.rotation.changed else None),
                 distortion=distortion or (self.distortion if self.distortion.changed else None),

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -186,11 +186,18 @@ class Player(RESTClient):
         volume : Volume
             Volume to set
         """
-        await self.node.volume(guild_id=self.channel.guild.id, volume=self.volume)
-        await self.seek(self.position, with_filter=True)
-        self._volume = volume
+        await self.set_filters(
+            volume=volume,
+            equalizer=self.equalizer,
+            karaoke=self.karaoke,
+            timescale=self.timescale,
+            tremolo=self.tremolo,
+            vibrato=self.vibrato,
+            rotation=self.rotation,
+            distortion=self.distortion,
+        )
 
-    async def set_equalizer(self, equalizer: Equalizer) -> None:
+    async def set_equalizer(self, equalizer: Equalizer, forced: bool = False) -> None:
         """
         Sets the Equalizer of Lavalink.
 
@@ -199,11 +206,19 @@ class Player(RESTClient):
         equalizer : Equalizer
             Equalizer to set
         """
-        await self.node.equalizer(guild_id=self.channel.guild.id, equalizer=equalizer)
-        await self.seek(self.position, with_filter=True)
-        self._equalizer = equalizer
+        await self.set_filters(
+            volume=self.volume,
+            equalizer=equalizer,
+            karaoke=self.karaoke if not forced else None,
+            timescale=self.timescale if not forced else None,
+            tremolo=self.tremolo if not forced else None,
+            vibrato=self.vibrato if not forced else None,
+            rotation=self.rotation if not forced else None,
+            distortion=self.distortion if not forced else None,
+            reset_not_reset=forced,
+        )
 
-    async def set_karaoke(self, karaoke: Karaoke) -> None:
+    async def set_karaoke(self, karaoke: Karaoke, forced: bool = False) -> None:
         """
         Sets the Karaoke of Lavalink.
 
@@ -212,11 +227,19 @@ class Player(RESTClient):
         karaoke : Karaoke
             Karaoke to set
         """
-        await self.node.karaoke(guild_id=self.channel.guild.id, karaoke=karaoke)
-        await self.seek(self.position, with_filter=True)
-        self._karaoke = karaoke
+        await self.set_filters(
+            volume=self.volume,
+            equalizer=self.equalizer if not forced else None,
+            karaoke=karaoke,
+            timescale=self.timescale if not forced else None,
+            tremolo=self.tremolo if not forced else None,
+            vibrato=self.vibrato if not forced else None,
+            rotation=self.rotation if not forced else None,
+            distortion=self.distortion if not forced else None,
+            reset_not_reset=forced,
+        )
 
-    async def set_timescale(self, timescale: Timescale) -> None:
+    async def set_timescale(self, timescale: Timescale, forced: bool = False) -> None:
         """
         Sets the Timescale of Lavalink.
 
@@ -225,11 +248,19 @@ class Player(RESTClient):
         timescale : Timescale
             Timescale to set
         """
-        await self.node.timescale(guild_id=self.channel.guild.id, timescale=timescale)
-        await self.seek(self.position, with_filter=True)
-        self._timescale = timescale
+        await self.set_filters(
+            volume=self.volume,
+            equalizer=self.equalizer if not forced else None,
+            karaoke=self.karaoke if not forced else None,
+            timescale=timescale,
+            tremolo=self.tremolo if not forced else None,
+            vibrato=self.vibrato if not forced else None,
+            rotation=self.rotation if not forced else None,
+            distortion=self.distortion if not forced else None,
+            reset_not_reset=forced,
+        )
 
-    async def set_tremolo(self, tremolo: Tremolo) -> None:
+    async def set_tremolo(self, tremolo: Tremolo, forced: bool = False) -> None:
         """
         Sets the Tremolo of Lavalink.
 
@@ -238,11 +269,19 @@ class Player(RESTClient):
         tremolo : Tremolo
             Tremolo to set
         """
-        await self.node.tremolo(guild_id=self.channel.guild.id, tremolo=tremolo)
-        await self.seek(self.position, with_filter=True)
-        self._tremolo = tremolo
+        await self.set_filters(
+            volume=self.volume,
+            equalizer=self.equalizer if not forced else None,
+            karaoke=self.karaoke if not forced else None,
+            timescale=self.timescale if not forced else None,
+            tremolo=tremolo,
+            vibrato=self.vibrato if not forced else None,
+            rotation=self.rotation if not forced else None,
+            distortion=self.distortion if not forced else None,
+            reset_not_reset=forced,
+        )
 
-    async def set_vibrato(self, vibrato: Vibrato) -> None:
+    async def set_vibrato(self, vibrato: Vibrato, forced: bool = False) -> None:
         """
         Sets the Vibrato of Lavalink.
 
@@ -251,11 +290,19 @@ class Player(RESTClient):
         vibrato : Vibrato
             Vibrato to set
         """
-        await self.node.vibrato(guild_id=self.channel.guild.id, vibrato=vibrato)
-        await self.seek(self.position, with_filter=True)
-        self._vibrato = vibrato
+        await self.set_filters(
+            volume=self.volume,
+            equalizer=self.equalizer if not forced else None,
+            karaoke=self.karaoke if not forced else None,
+            timescale=self.timescale if not forced else None,
+            tremolo=self.tremolo if not forced else None,
+            vibrato=vibrato,
+            rotation=self.rotation if not forced else None,
+            distortion=self.distortion if not forced else None,
+            reset_not_reset=forced,
+        )
 
-    async def set_rotation(self, rotation: Rotation) -> None:
+    async def set_rotation(self, rotation: Rotation, forced: bool = False) -> None:
         """
         Sets the Rotation of Lavalink.
 
@@ -264,11 +311,19 @@ class Player(RESTClient):
         rotation : Rotation
             Rotation to set
         """
-        await self.node.rotation(guild_id=self.channel.guild.id, rotation=rotation)
-        await self.seek(self.position, with_filter=True)
-        self._rotation = rotation
+        await self.set_filters(
+            volume=self.volume,
+            equalizer=self.equalizer if not forced else None,
+            karaoke=self.karaoke if not forced else None,
+            timescale=self.timescale if not forced else None,
+            tremolo=self.tremolo if not forced else None,
+            vibrato=self.vibrato if not forced else None,
+            rotation=rotation,
+            distortion=self.distortion if not forced else None,
+            reset_not_reset=forced,
+        )
 
-    async def set_distortion(self, distortion: Distortion) -> None:
+    async def set_distortion(self, distortion: Distortion, forced: bool = False) -> None:
         """
         Sets the Distortion of Lavalink.
 
@@ -277,9 +332,17 @@ class Player(RESTClient):
         distortion : Distortion
             Distortion to set
         """
-        await self.node.distortion(guild_id=self.channel.guild.id, distortion=distortion)
-        await self.seek(self.position, with_filter=True)
-        self._distortion = distortion
+        await self.set_filters(
+            volume=self.volume,
+            equalizer=self.equalizer if not forced else None,
+            karaoke=self.karaoke if not forced else None,
+            timescale=self.timescale if not forced else None,
+            tremolo=self.tremolo if not forced else None,
+            vibrato=self.vibrato if not forced else None,
+            rotation=self.rotation if not forced else None,
+            distortion=distortion,
+            reset_not_reset=forced,
+        )
 
     async def set_filters(
         self,
@@ -292,18 +355,32 @@ class Player(RESTClient):
         vibrato: Vibrato = None,
         rotation: Rotation = None,
         distortion: Distortion = None,
+        reset_not_reset: bool = False,
     ):
-        await self.node.filters(
-            guild_id=self.channel.guild.id,
-            volume=volume,
-            equalizer=equalizer,
-            karaoke=karaoke,
-            timescale=timescale,
-            tremolo=tremolo,
-            vibrato=vibrato,
-            rotation=rotation,
-            distortion=distortion,
-        )
+        if reset_not_reset:
+            await self.node.filters(
+                guild_id=self.channel.guild.id,
+                volume=volume,
+                equalizer=equalizer,
+                karaoke=karaoke,
+                timescale=timescale,
+                tremolo=tremolo,
+                vibrato=vibrato,
+                rotation=rotation,
+                distortion=distortion,
+            )
+        else:
+            await self.node.filters(
+                guild_id=self.channel.guild.id,
+                volume=self.volume,
+                equalizer=equalizer or self.equalizer,
+                karaoke=karaoke or self.karaoke,
+                timescale=timescale or self.timescale,
+                tremolo=tremolo or self.tremolo,
+                vibrato=vibrato or self.vibrato,
+                rotation=rotation or self.rotation,
+                distortion=distortion or self.distortion,
+            )
         if volume:
             self._volume = volume
         if equalizer:

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -188,13 +188,13 @@ class Player(RESTClient):
         """
         await self.set_filters(
             volume=volume,
-            equalizer=self.equalizer,
-            karaoke=self.karaoke,
-            timescale=self.timescale,
-            tremolo=self.tremolo,
-            vibrato=self.vibrato,
-            rotation=self.rotation,
-            distortion=self.distortion,
+            equalizer=self.equalizer if self.equalizer.changed else None,
+            karaoke=self.karaoke if self.karaoke.changed else None,
+            timescale=self.timescale if self.timescale.changed else None,
+            tremolo=self.tremolo if self.timescale.changed else None,
+            vibrato=self.vibrato if self.vibrato.changed else None,
+            rotation=self.rotation if self.rotation.changed else None,
+            distortion=self.distortion if self.distortion.changed else None,
         )
 
     async def set_equalizer(self, equalizer: Equalizer, forced: bool = False) -> None:
@@ -209,12 +209,12 @@ class Player(RESTClient):
         await self.set_filters(
             volume=self.volume,
             equalizer=equalizer,
-            karaoke=self.karaoke if not forced else None,
-            timescale=self.timescale if not forced else None,
-            tremolo=self.tremolo if not forced else None,
-            vibrato=self.vibrato if not forced else None,
-            rotation=self.rotation if not forced else None,
-            distortion=self.distortion if not forced else None,
+            karaoke=self.karaoke if self.karaoke.changed and not forced else None,
+            timescale=self.timescale if self.timescale.changed and not forced else None,
+            tremolo=self.tremolo if self.timescale.changed and not forced else None,
+            vibrato=self.vibrato if self.vibrato.changed and not forced else None,
+            rotation=self.rotation if self.rotation.changed and not forced else None,
+            distortion=self.distortion if self.distortion.changed and not forced else None,
             reset_not_reset=forced,
         )
 
@@ -229,13 +229,13 @@ class Player(RESTClient):
         """
         await self.set_filters(
             volume=self.volume,
-            equalizer=self.equalizer if not forced else None,
+            equalizer=self.equalizer if self.equalizer.changed and not forced else None,
             karaoke=karaoke,
-            timescale=self.timescale if not forced else None,
-            tremolo=self.tremolo if not forced else None,
-            vibrato=self.vibrato if not forced else None,
-            rotation=self.rotation if not forced else None,
-            distortion=self.distortion if not forced else None,
+            timescale=self.timescale if self.timescale.changed and not forced else None,
+            tremolo=self.tremolo if self.timescale.changed and not forced else None,
+            vibrato=self.vibrato if self.vibrato.changed and not forced else None,
+            rotation=self.rotation if self.rotation.changed and not forced else None,
+            distortion=self.distortion if self.distortion.changed and not forced else None,
             reset_not_reset=forced,
         )
 
@@ -250,13 +250,13 @@ class Player(RESTClient):
         """
         await self.set_filters(
             volume=self.volume,
-            equalizer=self.equalizer if not forced else None,
-            karaoke=self.karaoke if not forced else None,
+            equalizer=self.equalizer if self.equalizer.changed and not forced else None,
+            karaoke=self.karaoke if self.karaoke.changed and not forced else None,
             timescale=timescale,
-            tremolo=self.tremolo if not forced else None,
-            vibrato=self.vibrato if not forced else None,
-            rotation=self.rotation if not forced else None,
-            distortion=self.distortion if not forced else None,
+            tremolo=self.tremolo if self.timescale.changed and not forced else None,
+            vibrato=self.vibrato if self.vibrato.changed and not forced else None,
+            rotation=self.rotation if self.rotation.changed and not forced else None,
+            distortion=self.distortion if self.distortion.changed and not forced else None,
             reset_not_reset=forced,
         )
 
@@ -271,13 +271,13 @@ class Player(RESTClient):
         """
         await self.set_filters(
             volume=self.volume,
-            equalizer=self.equalizer if not forced else None,
-            karaoke=self.karaoke if not forced else None,
-            timescale=self.timescale if not forced else None,
+            equalizer=self.equalizer if self.equalizer.changed and not forced else None,
+            karaoke=self.karaoke if self.karaoke.changed and not forced else None,
+            timescale=self.timescale if self.timescale.changed and not forced else None,
             tremolo=tremolo,
-            vibrato=self.vibrato if not forced else None,
-            rotation=self.rotation if not forced else None,
-            distortion=self.distortion if not forced else None,
+            vibrato=self.vibrato if self.vibrato.changed and not forced else None,
+            rotation=self.rotation if self.rotation.changed and not forced else None,
+            distortion=self.distortion if self.distortion.changed and not forced else None,
             reset_not_reset=forced,
         )
 
@@ -292,13 +292,13 @@ class Player(RESTClient):
         """
         await self.set_filters(
             volume=self.volume,
-            equalizer=self.equalizer if not forced else None,
-            karaoke=self.karaoke if not forced else None,
-            timescale=self.timescale if not forced else None,
-            tremolo=self.tremolo if not forced else None,
+            equalizer=self.equalizer if self.equalizer.changed and not forced else None,
+            karaoke=self.karaoke if self.karaoke.changed and not forced else None,
+            timescale=self.timescale if self.timescale.changed and not forced else None,
+            tremolo=self.tremolo if self.timescale.changed and not forced else None,
             vibrato=vibrato,
-            rotation=self.rotation if not forced else None,
-            distortion=self.distortion if not forced else None,
+            rotation=self.rotation if self.rotation.changed and not forced else None,
+            distortion=self.distortion if self.distortion.changed and not forced else None,
             reset_not_reset=forced,
         )
 
@@ -313,13 +313,13 @@ class Player(RESTClient):
         """
         await self.set_filters(
             volume=self.volume,
-            equalizer=self.equalizer if not forced else None,
-            karaoke=self.karaoke if not forced else None,
-            timescale=self.timescale if not forced else None,
-            tremolo=self.tremolo if not forced else None,
-            vibrato=self.vibrato if not forced else None,
+            equalizer=self.equalizer if self.equalizer.changed and not forced else None,
+            karaoke=self.karaoke if self.karaoke.changed and not forced else None,
+            timescale=self.timescale if self.timescale.changed and not forced else None,
+            tremolo=self.tremolo if self.timescale.changed and not forced else None,
+            vibrato=self.vibrato if self.vibrato.changed and not forced else None,
             rotation=rotation,
-            distortion=self.distortion if not forced else None,
+            distortion=self.distortion if self.distortion.changed and not forced else None,
             reset_not_reset=forced,
         )
 
@@ -334,12 +334,12 @@ class Player(RESTClient):
         """
         await self.set_filters(
             volume=self.volume,
-            equalizer=self.equalizer if not forced else None,
-            karaoke=self.karaoke if not forced else None,
-            timescale=self.timescale if not forced else None,
-            tremolo=self.tremolo if not forced else None,
-            vibrato=self.vibrato if not forced else None,
-            rotation=self.rotation if not forced else None,
+            equalizer=self.equalizer if self.equalizer.changed and not forced else None,
+            karaoke=self.karaoke if self.karaoke.changed and not forced else None,
+            timescale=self.timescale if self.timescale.changed and not forced else None,
+            tremolo=self.tremolo if self.timescale.changed and not forced else None,
+            vibrato=self.vibrato if self.vibrato.changed and not forced else None,
+            rotation=self.rotation if self.rotation.changed and not forced else None,
             distortion=distortion,
             reset_not_reset=forced,
         )
@@ -370,16 +370,24 @@ class Player(RESTClient):
                 distortion=distortion,
             )
         else:
+            equalizer = (self.equalizer if self.equalizer.changed else None,)
+            karaoke = (self.karaoke if self.karaoke.changed else None,)
+            timescale = (self.timescale if self.timescale.changed else None,)
+            tremolo = (self.tremolo if self.timescale.changed else None,)
+            vibrato = (self.vibrato if self.vibrato.changed else None,)
+            rotation = (self.rotation if self.rotation.changed else None,)
+            distortion = (self.distortion if self.distortion.changed else None,)
+
             await self.node.filters(
                 guild_id=self.channel.guild.id,
                 volume=self.volume,
-                equalizer=equalizer or self.equalizer,
-                karaoke=karaoke or self.karaoke,
-                timescale=timescale or self.timescale,
-                tremolo=tremolo or self.tremolo,
-                vibrato=vibrato or self.vibrato,
-                rotation=rotation or self.rotation,
-                distortion=distortion or self.distortion,
+                equalizer=equalizer or self.equalizer if self.equalizer.changed else None,
+                karaoke=karaoke or self.karaoke if self.karaoke.changed else None,
+                timescale=timescale or self.timescale if self.timescale.changed else None,
+                tremolo=tremolo or self.tremolo if self.timescale.changed else None,
+                vibrato=vibrato or self.vibrato if self.vibrato.changed else None,
+                rotation=rotation or self.rotation if self.rotation.changed else None,
+                distortion=distortion or self.distortion if self.distortion.changed else None,
             )
         if volume:
             self._volume = volume

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -299,9 +299,9 @@ class Player(RESTClient):
         vibrato: Vibrato = None,
         rotation: Rotation = None,
         distortion: Distortion = None,
-        reset_not_reset: bool = False,
+        reset_not_set: bool = False,
     ):
-        if reset_not_reset:
+        if reset_not_set:
             await self.node.filters(
                 guild_id=self.channel.guild.id,
                 volume=volume,

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -48,6 +48,7 @@ class Player(RESTClient):
         self._last_channel_id = channel.id
         self.queue = []
         self.position = 0
+        self.connected = False
         self.current = None  # type: Track
         self._paused = False
         self.repeat = False
@@ -461,9 +462,19 @@ class Player(RESTClient):
         state : websocket.PlayerState
         """
         if state.position > self.position:
-            self._is_playing = True
+            if state.connected:
+                self._is_playing = True
+            else:
+                self._is_playing = False
+                log.debug(
+                    f"Player position changed but player isn't connected. (Ignoring position update), %r", self
+                )
+                self.position = state.position
+
+                return
         log.debug("Updated player position for player: %r - %ds.", self, state.position // 1000)
         self.position = state.position
+        self.connected = state.connected
 
     # Play commands
     def add(self, requester: discord.User, track: Track):

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -188,13 +188,6 @@ class Player(RESTClient):
         """
         await self.set_filters(
             volume=volume,
-            equalizer=self.equalizer if self.equalizer.changed else None,
-            karaoke=self.karaoke if self.karaoke.changed else None,
-            timescale=self.timescale if self.timescale.changed else None,
-            tremolo=self.tremolo if self.timescale.changed else None,
-            vibrato=self.vibrato if self.vibrato.changed else None,
-            rotation=self.rotation if self.rotation.changed else None,
-            distortion=self.distortion if self.distortion.changed else None,
         )
 
     async def set_equalizer(self, equalizer: Equalizer, forced: bool = False) -> None:
@@ -207,14 +200,7 @@ class Player(RESTClient):
             Equalizer to set
         """
         await self.set_filters(
-            volume=self.volume,
             equalizer=equalizer,
-            karaoke=self.karaoke if self.karaoke.changed and not forced else None,
-            timescale=self.timescale if self.timescale.changed and not forced else None,
-            tremolo=self.tremolo if self.timescale.changed and not forced else None,
-            vibrato=self.vibrato if self.vibrato.changed and not forced else None,
-            rotation=self.rotation if self.rotation.changed and not forced else None,
-            distortion=self.distortion if self.distortion.changed and not forced else None,
             reset_not_reset=forced,
         )
 
@@ -228,14 +214,7 @@ class Player(RESTClient):
             Karaoke to set
         """
         await self.set_filters(
-            volume=self.volume,
-            equalizer=self.equalizer if self.equalizer.changed and not forced else None,
             karaoke=karaoke,
-            timescale=self.timescale if self.timescale.changed and not forced else None,
-            tremolo=self.tremolo if self.timescale.changed and not forced else None,
-            vibrato=self.vibrato if self.vibrato.changed and not forced else None,
-            rotation=self.rotation if self.rotation.changed and not forced else None,
-            distortion=self.distortion if self.distortion.changed and not forced else None,
             reset_not_reset=forced,
         )
 
@@ -249,14 +228,7 @@ class Player(RESTClient):
             Timescale to set
         """
         await self.set_filters(
-            volume=self.volume,
-            equalizer=self.equalizer if self.equalizer.changed and not forced else None,
-            karaoke=self.karaoke if self.karaoke.changed and not forced else None,
             timescale=timescale,
-            tremolo=self.tremolo if self.timescale.changed and not forced else None,
-            vibrato=self.vibrato if self.vibrato.changed and not forced else None,
-            rotation=self.rotation if self.rotation.changed and not forced else None,
-            distortion=self.distortion if self.distortion.changed and not forced else None,
             reset_not_reset=forced,
         )
 
@@ -270,14 +242,7 @@ class Player(RESTClient):
             Tremolo to set
         """
         await self.set_filters(
-            volume=self.volume,
-            equalizer=self.equalizer if self.equalizer.changed and not forced else None,
-            karaoke=self.karaoke if self.karaoke.changed and not forced else None,
-            timescale=self.timescale if self.timescale.changed and not forced else None,
             tremolo=tremolo,
-            vibrato=self.vibrato if self.vibrato.changed and not forced else None,
-            rotation=self.rotation if self.rotation.changed and not forced else None,
-            distortion=self.distortion if self.distortion.changed and not forced else None,
             reset_not_reset=forced,
         )
 
@@ -291,14 +256,7 @@ class Player(RESTClient):
             Vibrato to set
         """
         await self.set_filters(
-            volume=self.volume,
-            equalizer=self.equalizer if self.equalizer.changed and not forced else None,
-            karaoke=self.karaoke if self.karaoke.changed and not forced else None,
-            timescale=self.timescale if self.timescale.changed and not forced else None,
-            tremolo=self.tremolo if self.timescale.changed and not forced else None,
             vibrato=vibrato,
-            rotation=self.rotation if self.rotation.changed and not forced else None,
-            distortion=self.distortion if self.distortion.changed and not forced else None,
             reset_not_reset=forced,
         )
 
@@ -312,14 +270,7 @@ class Player(RESTClient):
             Rotation to set
         """
         await self.set_filters(
-            volume=self.volume,
-            equalizer=self.equalizer if self.equalizer.changed and not forced else None,
-            karaoke=self.karaoke if self.karaoke.changed and not forced else None,
-            timescale=self.timescale if self.timescale.changed and not forced else None,
-            tremolo=self.tremolo if self.timescale.changed and not forced else None,
-            vibrato=self.vibrato if self.vibrato.changed and not forced else None,
             rotation=rotation,
-            distortion=self.distortion if self.distortion.changed and not forced else None,
             reset_not_reset=forced,
         )
 
@@ -333,13 +284,6 @@ class Player(RESTClient):
             Distortion to set
         """
         await self.set_filters(
-            volume=self.volume,
-            equalizer=self.equalizer if self.equalizer.changed and not forced else None,
-            karaoke=self.karaoke if self.karaoke.changed and not forced else None,
-            timescale=self.timescale if self.timescale.changed and not forced else None,
-            tremolo=self.tremolo if self.timescale.changed and not forced else None,
-            vibrato=self.vibrato if self.vibrato.changed and not forced else None,
-            rotation=self.rotation if self.rotation.changed and not forced else None,
             distortion=distortion,
             reset_not_reset=forced,
         )
@@ -372,7 +316,7 @@ class Player(RESTClient):
         else:
             await self.node.filters(
                 guild_id=self.channel.guild.id,
-                volume=self.volume,
+                volume=volume or self.volume,
                 equalizer=equalizer or (self.equalizer if self.equalizer.changed else None),
                 karaoke=karaoke or (self.karaoke if self.karaoke.changed else None),
                 timescale=timescale or (self.timescale if self.timescale.changed else None),

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -95,37 +95,37 @@ class Player(RESTClient):
         return self._volume
 
     @property
-    def equalizer(self):
+    def equalizer(self) -> Equalizer:
         """The currently applied Equalizer filter."""
         return self._equalizer
 
     @property
-    def karaoke(self):
+    def karaoke(self) -> Karaoke:
         """The currently applied Karaoke filter."""
         return self._karaoke
 
     @property
-    def timescale(self):
+    def timescale(self) -> Timescale:
         """The currently applied Timescale filter."""
         return self._timescale
 
     @property
-    def tremolo(self):
+    def tremolo(self) -> Tremolo:
         """The currently applied Tremolo filter."""
         return self._tremolo
 
     @property
-    def vibrato(self):
+    def vibrato(self) -> Vibrato:
         """The currently applied Vibrato filter."""
         return self._vibrato
 
     @property
-    def rotation(self):
+    def rotation(self) -> Rotation:
         """The currently applied Rotation filter."""
         return self._rotation
 
     @property
-    def distortion(self):
+    def distortion(self) -> Distortion:
         """The currently applied Distortion filter."""
         return self._distortion
 

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -281,7 +281,7 @@ class Player(RESTClient):
         rotation: Rotation = None,
         distortion: Distortion = None,
     ):
-        await self.node.filter(
+        await self.node.filters(
             guild_id=self.channel.guild.id,
             volume=volume,
             equalizer=equalizer,

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -622,7 +622,7 @@ class Player(RESTClient):
                 now = time.time_ns() // 1_000_000
                 if self.position > position:
                     position = self.position
-                position += (now - self._last_filter)
+                position += now - self._last_filter
 
             await self.node.seek(self.guild.id, position)
 

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -260,6 +260,46 @@ class Player(RESTClient):
         await self.node.distortion(guild_id=self.channel.guild.id, distortion=distortion)
         self._distortion = distortion
 
+    async def set_filters(
+        self,
+        *,
+        volume: Volume = None,
+        equalizer: Equalizer = None,
+        karaoke: Karaoke = None,
+        timescale: Timescale = None,
+        tremolo: Tremolo = None,
+        vibrato: Vibrato = None,
+        rotation: Rotation = None,
+        distortion: Distortion = None,
+    ):
+        await self.node.filter(
+            guild_id=self.channel.guild.id,
+            volume=volume,
+            equalizer=equalizer,
+            karaoke=karaoke,
+            timescale=timescale,
+            tremolo=tremolo,
+            vibrato=vibrato,
+            rotation=rotation,
+            distortion=distortion,
+        )
+        if volume:
+            self._volume = volume
+        if equalizer:
+            self._equalizer = equalizer
+        if karaoke:
+            self._karaoke = karaoke
+        if timescale:
+            self._timescale = timescale
+        if tremolo:
+            self._tremolo = tremolo
+        if vibrato:
+            self._vibrato = vibrato
+        if rotation:
+            self._rotation = rotation
+        if distortion:
+            self._distortion = distortion
+
     async def wait_until_ready(
         self, timeout: Optional[float] = None, no_raise: bool = False
     ) -> bool:

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -209,7 +209,7 @@ class Player(RESTClient):
         """
         await self.set_filters(
             equalizer=equalizer,
-            reset_not_reset=forced,
+            reset_not_set=forced,
         )
 
     async def set_karaoke(self, karaoke: Karaoke, forced: bool = False) -> None:
@@ -223,7 +223,7 @@ class Player(RESTClient):
         """
         await self.set_filters(
             karaoke=karaoke,
-            reset_not_reset=forced,
+            reset_not_set=forced,
         )
 
     async def set_timescale(self, timescale: Timescale, forced: bool = False) -> None:
@@ -237,7 +237,7 @@ class Player(RESTClient):
         """
         await self.set_filters(
             timescale=timescale,
-            reset_not_reset=forced,
+            reset_not_set=forced,
         )
 
     async def set_tremolo(self, tremolo: Tremolo, forced: bool = False) -> None:
@@ -251,7 +251,7 @@ class Player(RESTClient):
         """
         await self.set_filters(
             tremolo=tremolo,
-            reset_not_reset=forced,
+            reset_not_set=forced,
         )
 
     async def set_vibrato(self, vibrato: Vibrato, forced: bool = False) -> None:
@@ -265,7 +265,7 @@ class Player(RESTClient):
         """
         await self.set_filters(
             vibrato=vibrato,
-            reset_not_reset=forced,
+            reset_not_set=forced,
         )
 
     async def set_rotation(self, rotation: Rotation, forced: bool = False) -> None:
@@ -279,7 +279,7 @@ class Player(RESTClient):
         """
         await self.set_filters(
             rotation=rotation,
-            reset_not_reset=forced,
+            reset_not_set=forced,
         )
 
     async def set_distortion(self, distortion: Distortion, forced: bool = False) -> None:
@@ -293,7 +293,7 @@ class Player(RESTClient):
         """
         await self.set_filters(
             distortion=distortion,
-            reset_not_reset=forced,
+            reset_not_set=forced,
         )
 
     async def set_filters(

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -175,6 +175,7 @@ class Player(RESTClient):
             Volume to set
         """
         await self.node.volume(guild_id=self.channel.guild.id, volume=self.volume)
+        await self.seek(self.position)
         self._volume = volume
 
     async def set_equalizer(self, equalizer: Equalizer) -> None:
@@ -187,6 +188,7 @@ class Player(RESTClient):
             Equalizer to set
         """
         await self.node.equalizer(guild_id=self.channel.guild.id, equalizer=equalizer)
+        await self.seek(self.position)
         self._equalizer = equalizer
 
     async def set_karaoke(self, karaoke: Karaoke) -> None:
@@ -199,6 +201,7 @@ class Player(RESTClient):
             Karaoke to set
         """
         await self.node.karaoke(guild_id=self.channel.guild.id, karaoke=karaoke)
+        await self.seek(self.position)
         self._karaoke = karaoke
 
     async def set_timescale(self, timescale: Timescale) -> None:
@@ -211,6 +214,7 @@ class Player(RESTClient):
             Timescale to set
         """
         await self.node.timescale(guild_id=self.channel.guild.id, timescale=timescale)
+        await self.seek(self.position)
         self._timescale = timescale
 
     async def set_tremolo(self, tremolo: Tremolo) -> None:
@@ -223,6 +227,7 @@ class Player(RESTClient):
             Tremolo to set
         """
         await self.node.tremolo(guild_id=self.channel.guild.id, tremolo=tremolo)
+        await self.seek(self.position)
         self._tremolo = tremolo
 
     async def set_vibrato(self, vibrato: Vibrato) -> None:
@@ -235,6 +240,7 @@ class Player(RESTClient):
             Vibrato to set
         """
         await self.node.vibrato(guild_id=self.channel.guild.id, vibrato=vibrato)
+        await self.seek(self.position)
         self._vibrato = vibrato
 
     async def set_rotation(self, rotation: Rotation) -> None:
@@ -247,6 +253,7 @@ class Player(RESTClient):
             Rotation to set
         """
         await self.node.rotation(guild_id=self.channel.guild.id, rotation=rotation)
+        await self.seek(self.position)
         self._rotation = rotation
 
     async def set_distortion(self, distortion: Distortion) -> None:
@@ -259,6 +266,7 @@ class Player(RESTClient):
             Distortion to set
         """
         await self.node.distortion(guild_id=self.channel.guild.id, distortion=distortion)
+        await self.seek(self.position)
         self._distortion = distortion
 
     async def set_filters(
@@ -300,6 +308,7 @@ class Player(RESTClient):
             self._rotation = rotation
         if distortion:
             self._distortion = distortion
+        await self.seek(self.position)
 
     async def wait_until_ready(
         self, timeout: Optional[float] = None, no_raise: bool = False

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -49,7 +49,7 @@ class Player(RESTClient):
         self._last_channel_id = channel.id
         self.queue = []
         self._position = 0
-        self.connected = False
+        self.ll_connected = False
         self.current = None  # type: Track
         self._paused = False
         self.repeat = False
@@ -524,7 +524,7 @@ class Player(RESTClient):
         log.debug("Updated player position for player: %r - %ds.", self, state.position // 1000)
         self._last_update = time.time_ns() // 1_000_000
         self._position = state.position
-        self.connected = state.connected
+        self.ll_connected = state.connected
 
     # Play commands
     def add(self, requester: discord.User, track: Track):

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -8,6 +8,7 @@ from discord.backoff import ExponentialBackoff
 
 from . import log, ws_rll_log
 from .enums import *
+from .filters import Distortion, Equalizer, Karaoke, Rotation, Timescale, Tremolo, Vibrato, Volume
 from .rest_api import RESTClient, Track
 
 if TYPE_CHECKING:
@@ -54,10 +55,19 @@ class Player(RESTClient):
         self.shuffle_bumped = True
         self._is_autoplaying = False
         self._auto_play_sent = False
-        self._volume = 1.0
         self.state = PlayerState.CREATED
         self.connected_at = None
         self._connected = False
+
+        # Filters
+        self._volume: Volume = Volume.default()
+        self._equalizer: Equalizer = Equalizer.default()
+        self._karaoke: Karaoke = Karaoke.default()
+        self._timescale: Timescale = Timescale.default()
+        self._tremolo: Tremolo = Tremolo.default()
+        self._vibrato: Vibrato = Vibrato.default()
+        self._rotation: Rotation = Rotation.default()
+        self._distortion: Distortion = Distortion.default()
 
         self._is_playing = False
         self._metadata = {}
@@ -76,6 +86,48 @@ class Player(RESTClient):
             f"position={self.position}, "
             f"length={self.current.length if self.current else 0}, node={self.node!r}>"
         )
+
+    @property
+    def volume(self) -> Volume:
+        """
+        The current volume.
+        """
+        return self._volume
+
+    @property
+    def equalizer(self):
+        """The currently applied Equalizer filter."""
+        return self._equalizer
+
+    @property
+    def karaoke(self):
+        """The currently applied Karaoke filter."""
+        return self._karaoke
+
+    @property
+    def timescale(self):
+        """The currently applied Timescale filter."""
+        return self._timescale
+
+    @property
+    def tremolo(self):
+        """The currently applied Tremolo filter."""
+        return self._tremolo
+
+    @property
+    def vibrato(self):
+        """The currently applied Vibrato filter."""
+        return self._vibrato
+
+    @property
+    def rotation(self):
+        """The currently applied Rotation filter."""
+        return self._rotation
+
+    @property
+    def distortion(self):
+        """The currently applied Distortion filter."""
+        return self._distortion
 
     @property
     def is_auto_playing(self) -> bool:
@@ -99,13 +151,6 @@ class Player(RESTClient):
         return self._paused
 
     @property
-    def volume(self) -> float:
-        """
-        The current volume.
-        """
-        return self._volume
-
-    @property
     def ready(self) -> bool:
         """
         Whether the underlying node is ready for requests.
@@ -118,6 +163,102 @@ class Player(RESTClient):
         Whether the player is ready to be used.
         """
         return self._connected
+
+    async def set_volume(self, volume: Volume):
+        """
+        Sets the volume of Lavalink.
+
+        Parameters
+        ----------
+        volume : Volume
+            Volume to set
+        """
+        await self.node.volume(guild_id=self.channel.guild.id, volume=self.volume)
+        self._volume = volume
+
+    async def set_equalizer(self, equalizer: Equalizer) -> None:
+        """
+        Sets the Equalizer of Lavalink.
+
+        Parameters
+        ----------
+        equalizer : Equalizer
+            Equalizer to set
+        """
+        await self.node.equalizer(guild_id=self.channel.guild.id, equalizer=equalizer)
+        self._equalizer = equalizer
+
+    async def set_karaoke(self, karaoke: Karaoke) -> None:
+        """
+        Sets the Karaoke of Lavalink.
+
+        Parameters
+        ----------
+        karaoke : Karaoke
+            Karaoke to set
+        """
+        await self.node.karaoke(guild_id=self.channel.guild.id, karaoke=karaoke)
+        self._karaoke = karaoke
+
+    async def set_timescale(self, timescale: Timescale) -> None:
+        """
+        Sets the Timescale of Lavalink.
+
+        Parameters
+        ----------
+        timescale : Timescale
+            Timescale to set
+        """
+        await self.node.timescale(guild_id=self.channel.guild.id, timescale=timescale)
+        self._timescale = timescale
+
+    async def set_tremolo(self, tremolo: Tremolo) -> None:
+        """
+        Sets the Tremolo of Lavalink.
+
+        Parameters
+        ----------
+        tremolo : Tremolo
+            Tremolo to set
+        """
+        await self.node.tremolo(guild_id=self.channel.guild.id, tremolo=tremolo)
+        self._tremolo = tremolo
+
+    async def set_vibrato(self, vibrato: Vibrato) -> None:
+        """
+        Sets the Vibrato of Lavalink.
+
+        Parameters
+        ----------
+        vibrato : Vibrato
+            Vibrato to set
+        """
+        await self.node.vibrato(guild_id=self.channel.guild.id, vibrato=vibrato)
+        self._vibrato = vibrato
+
+    async def set_rotation(self, rotation: Rotation) -> None:
+        """
+        Sets the Rotation of Lavalink.
+
+        Parameters
+        ----------
+        rotation : Rotation
+            Rotation to set
+        """
+        await self.node.rotation(guild_id=self.channel.guild.id, rotation=rotation)
+        self._rotation = rotation
+
+    async def set_distortion(self, distortion: Distortion) -> None:
+        """
+        Sets the Distortion of Lavalink.
+
+        Parameters
+        ----------
+        distortion : Distortion
+            Distortion to set
+        """
+        await self.node.distortion(guild_id=self.channel.guild.id, distortion=distortion)
+        self._distortion = distortion
 
     async def wait_until_ready(
         self, timeout: Optional[float] = None, no_raise: bool = False
@@ -394,18 +535,6 @@ class Player(RESTClient):
 
         self._paused = pause
         await self.node.pause(self.guild.id, pause)
-
-    async def set_volume(self, volume: float):
-        """
-        Sets the volume of Lavalink.
-
-        Parameters
-        ----------
-        volume : float
-            Greater and 0
-        """
-        self._volume = max(volume, 0.0)
-        await self.node.volume(self.guild.id, self.volume)
 
     async def seek(self, position: int):
         """

--- a/lavalink/rest_api.py
+++ b/lavalink/rest_api.py
@@ -6,6 +6,11 @@ from urllib.parse import quote, urlparse
 from aiohttp import ClientSession
 from aiohttp.client_exceptions import ServerDisconnectedError
 
+try:
+    from redbot import json
+except ImportError:
+    import json
+
 from . import log
 from .enums import *
 
@@ -287,7 +292,7 @@ class RESTClient:
 
     def reset_session(self):
         if self._session is None or self._session.closed:
-            self._session = ClientSession(loop=self.node.loop)
+            self._session = ClientSession(loop=self.node.loop, json_serialize=json.dumps)
 
     def __check_node_ready(self):
         if self.state != PlayerState.READY:
@@ -296,7 +301,7 @@ class RESTClient:
     async def _get(self, url):
         try:
             async with self._session.get(url, headers=self._headers) as resp:
-                data = await resp.json(content_type=None)
+                data = await resp.json(content_type=None, loads=json.loads)
         except ServerDisconnectedError:
             if self.state == PlayerState.DISCONNECTING:
                 return {

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ packages =
 python_requires = >3.8.0
 install_requires =
     discord.py>=1.5.1
-    aiohttp>=3.6.0
+    aiohttp[speedups]>=3.7.4
 
 [options.extras_require]
 tests =

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ packages =
 python_requires = >3.8.0
 install_requires =
     discord.py>=1.5.1
-    aiohttp[speedups]>=3.7.4
+    aiohttp[speedups]>=3.7.3
 
 [options.extras_require]
 tests =

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os.path
 import re
+
 from setuptools import setup
 
 root_dir = os.path.abspath(os.path.dirname(__file__))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,11 @@
+import asyncio
 from collections import namedtuple
 from types import SimpleNamespace
-
-import pytest
-import asyncio
 from unittest.mock import MagicMock, patch
 
-from discord.gateway import DiscordWebSocket
+import pytest
 from discord.ext.commands import AutoShardedBot
+from discord.gateway import DiscordWebSocket
 
 import lavalink.node
 

--- a/tests/test_lavalink.py
+++ b/tests/test_lavalink.py
@@ -1,8 +1,8 @@
 import pytest
 
 import lavalink
-import lavalink.player_manager
 import lavalink.node
+import lavalink.player_manager
 
 
 @pytest.mark.asyncio

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,7 +1,7 @@
 from copy import copy
 
-import pytest
 import aiohttp
+import pytest
 
 
 @pytest.mark.asyncio

--- a/tests/test_player_manager.py
+++ b/tests/test_player_manager.py
@@ -1,7 +1,7 @@
 import pytest
 
-import lavalink.player_manager
 import lavalink.node
+import lavalink.player_manager
 
 
 @pytest.fixture


### PR DESCRIPTION
This is a fairly breaking PR as it completely changes how EQ and Volume works within RLL, so bumping it to 0.9.0.

Implements the following changes:
- * The error string on the TrackExceptionEvent has been deprecated and replaced by 
the exception object following the same structure as the LOAD_FAILED error on [/loadtracks](#rest-api)
- * Added the connected boolean to player updates.
- * The Num-Shards header got removed
- * Volume and EQ moved to filter op

While implementing the above also added the filter objects to atempt to simplify the usage of filter on the clientand filter apis from both the PlayerManager and Node Objects.

# Breaking Change:
- Volume now expects a Volume class and will not accept an int
- Volume accepted values is now a float greater than 0 (before it was a intiger between 0 and 150)
- Volume artificial cap of 150 has been removed.

Changes:
- Added EQ Support via apis so it no longer needs to be handled client side.