### PR TITLE
Remove max Python version requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ classifiers =
 [options]
 packages =
     lavalink
-python_requires = >3.8.0, <3.9
+python_requires = >3.8.0
 install_requires =
     discord.py>=1.5.1
     aiohttp>=3.6.0


### PR DESCRIPTION
Since we don't care about non-Red usage of this library, there's really no point in specifying a maximum supported version as it will only make it harder for us to update Red to support newer Python versions in the future.