### PR TITLE
Add project files from VS Code and Sublime Text to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,12 @@ venv.bak/
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 .idea
 
+# User-specific stuff:
+*.iws
+.vscode/
+*.sublime-project
+*.sublime-workspace
+
 # CMake
 cmake-build-debug/
 cmake-build-release/

--- a/.gitignore
+++ b/.gitignore
@@ -110,7 +110,6 @@ venv.bak/
 .idea
 
 # User-specific stuff:
-*.iws
 .vscode/
 *.sublime-project
 *.sublime-workspace


### PR DESCRIPTION
I noticed it was missing some of them when linking my venv on vscode, so I took those from Red `.gitignore` file.