### PR TITLE
Fix ghost players

### DIFF
--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -43,4 +43,4 @@ __all__ = [
     "all_connected_players",
     "active_players",
 ]
-__version__ = "0.8.2"
+__version__ = "0.8.1"

--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -43,4 +43,4 @@ __all__ = [
     "all_connected_players",
     "active_players",
 ]
-__version__ = "0.8.1"
+__version__ = "0.8.2"

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -264,7 +264,6 @@ class Player(RESTClient):
             self._is_playing = False
             if extra == TrackEndReason.FINISHED:
                 await self.play()
-
         elif event == LavalinkEvents.WEBSOCKET_CLOSED:
             code = extra.get("code")
             if code in (4015, 4014, 4009, 4006, 4000, 1006):

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -371,6 +371,7 @@ class Player(RESTClient):
         self._paused = False
         self._is_autoplaying = False
         self._auto_play_sent = False
+        self._is_playing = False
 
     async def skip(self):
         """

--- a/lavalink/player_manager.py
+++ b/lavalink/player_manager.py
@@ -261,10 +261,10 @@ class Player(RESTClient):
         log.debug("Received player event for player: %r - %r - %r.", self, event, extra)
 
         if event == LavalinkEvents.TRACK_END:
+            self._is_playing = False
             if extra == TrackEndReason.FINISHED:
                 await self.play()
-            else:
-                self._is_playing = False
+
         elif event == LavalinkEvents.WEBSOCKET_CLOSED:
             code = extra.get("code")
             if code in (4015, 4014, 4009, 4006, 4000, 1006):


### PR DESCRIPTION
Some players on RLL get stuck in a playing state when they are stopped. The private Player._is_playing designation, which is copied over to the public Player.is_playing designation, reports that these players are still playing. This PR properly sets those players' is_playing to False. Ghost player situations like this will also be improved with a later PR to support Lavalink 3.4 jars, where a destroy method will be called on players instead of a stop method.