### PR TITLE
Add FAULT/remove FATAL exception severity

### DIFF
--- a/lavalink/enums.py
+++ b/lavalink/enums.py
@@ -135,5 +135,4 @@ class LoadType(enum.Enum):
 class ExceptionSeverity(enum.Enum):
     COMMON = "COMMON"
     SUSPICIOUS = "SUSPICIOUS"
-    FATAL = "FATAL"
     FAULT = "FAULT"

--- a/lavalink/enums.py
+++ b/lavalink/enums.py
@@ -136,3 +136,4 @@ class ExceptionSeverity(enum.Enum):
     COMMON = "COMMON"
     SUSPICIOUS = "SUSPICIOUS"
     FATAL = "FATAL"
+    FAULT = "FAULT"


### PR DESCRIPTION
Certain tracks can end up being a FAULT severity, which isn't in our enums.

Example tracks:
https://cdn.discordapp.com/attachments/169456266240983041/932099216166252574/721770.mp4
https://cdn.discordapp.com/attachments/692039523965861988/856151137483620402/WhatsApp_Video_2021-04-02_at_22.03.20_1.mp4
https://cdn.discordapp.com/attachments/583996272898342912/857341893432180766/yoga_time.mp4

Current response before PR:
```
[2022-01-16 23:17:04] [CRITICAL] red.main: Caught unhandled exception in <Task finished name='Task-115252304' coro=<Node._handle_op() done, defined at /.../cat38/lib/python3.8/site-packages/lavalink/node.py:363> exception=ValueError("'FAULT' is not a valid ExceptionSeverity")>:
Task exception was never retrieved
Traceback (most recent call last):
  File "/.../cat38/lib/python3.8/site-packages/lavalink/node.py", line 370, in _handle_op
    self.event_handler(op, event, data)
  File "/.../cat38/lib/python3.8/site-packages/lavalink/lavalink.py", line 331, in dispatch
    args = _get_event_args(data, raw_data)
  File "/.../cat38/lib/python3.8/site-packages/lavalink/lavalink.py", line 203, in _get_event_args
    "severity": enums.ExceptionSeverity(exception_data["severity"]),
  File "/usr/lib/python3.8/enum.py", line 339, in __call__
    return cls.__new__(cls, value)
  File "/usr/lib/python3.8/enum.py", line 663, in __new__
    raise ve_exc
ValueError: 'FAULT' is not a valid ExceptionSeverity
```
 The Track Error dialog box for the audio cog is never sent with this traceback occuring. After this PR it's sent properly.
 <img width="338" alt="Screen Shot 2022-01-17 at 10 57 03 AM" src="https://user-images.githubusercontent.com/20862007/149824617-40372d7b-2430-44d4-8896-b33a5ee3879f.png">