### PR TITLE
Make port arg optional (for connecting to domains)

### DIFF
--- a/lavalink/lavalink.py
+++ b/lavalink/lavalink.py
@@ -57,6 +57,7 @@ async def initialize(
         The password of the Lavalink node.
     port : Optional[int]
         The websocket port on the Lavalink Node.
+        If not provided, it will use 80 for unsecured connections and 443 for secured.
     timeout : float
         Amount of time to allow retries to occur, ``None`` is considered forever.
     resume_key : Optional[str]

--- a/lavalink/lavalink.py
+++ b/lavalink/lavalink.py
@@ -33,7 +33,7 @@ async def initialize(
     bot: Bot,
     host,
     password,
-    ws_port,
+    port: Optional[int] = None,
     timeout=30,
     resume_key: Optional[str] = None,
     resume_timeout: int = 60,
@@ -55,7 +55,7 @@ async def initialize(
         The hostname or IP address of the Lavalink node.
     password : str
         The password of the Lavalink node.
-    ws_port : int
+    port : Optional[int]
         The websocket port on the Lavalink Node.
     timeout : int
         Amount of time to allow retries to occur, ``None`` is considered forever.
@@ -79,7 +79,7 @@ async def initialize(
         bot._connection._get_websocket,
         host,
         password,
-        port=ws_port,
+        port=port,
         user_id=player_manager.user_id,
         num_shards=bot.shard_count if bot.shard_count is not None else 1,
         resume_key=resume_key,

--- a/lavalink/lavalink.py
+++ b/lavalink/lavalink.py
@@ -64,7 +64,7 @@ async def initialize(
     resume_timeout : float
         How long the node should wait for a connection while disconnected before clearing all players.
     secured: bool
-           Whether to use the `wss://` and `https://` protocol.
+        Whether to use the `wss://` and `https://` protocol.
     """
     global _loop
     _loop = bot.loop
@@ -74,11 +74,11 @@ async def initialize(
     register_update_listener(_handle_update)
 
     lavalink_node = node.Node(
-        _loop,
-        dispatch,
-        bot._connection._get_websocket,
-        host,
-        password,
+        loop=_loop,
+        event_handler=dispatch,
+        voice_ws_func=bot._connection._get_websocket,
+        host=host,
+        password=password,
         port=port,
         user_id=player_manager.user_id,
         num_shards=bot.shard_count if bot.shard_count is not None else 1,

--- a/lavalink/lavalink.py
+++ b/lavalink/lavalink.py
@@ -34,9 +34,9 @@ async def initialize(
     host,
     password,
     port: Optional[int] = None,
-    timeout=30,
+    timeout: float = 30,
     resume_key: Optional[str] = None,
-    resume_timeout: int = 60,
+    resume_timeout: float = 60,
     secured: bool = False,
 ):
     """
@@ -57,11 +57,11 @@ async def initialize(
         The password of the Lavalink node.
     port : Optional[int]
         The websocket port on the Lavalink Node.
-    timeout : int
+    timeout : float
         Amount of time to allow retries to occur, ``None`` is considered forever.
     resume_key : Optional[str]
         A resume key used for resuming a session upon re-establishing a WebSocket connection to Lavalink.
-    resume_timeout : inr
+    resume_timeout : float
         How long the node should wait for a connection while disconnected before clearing all players.
     secured: bool
            Whether to use the `wss://` and `https://` protocol.
@@ -106,7 +106,10 @@ async def connect(channel: discord.VoiceChannel, deafen: bool = False):
 
     Parameters
     ----------
-    channel
+    channel : discord.VoiceChannel
+        The channel to connect to.
+    deafen: bool
+        Whether to deafen the bot user upon join.
 
     Returns
     -------

--- a/lavalink/node.py
+++ b/lavalink/node.py
@@ -120,9 +120,9 @@ class Node:
         voice_ws_func: typing.Callable,
         host: str,
         password: str,
-        port: int,
         user_id: int,
         num_shards: int,
+        port: Optional[int] = None,
         resume_key: Optional[str] = None,
         resume_timeout: int = 60,
         bot: Bot = None,
@@ -143,7 +143,7 @@ class Node:
             Lavalink player host.
         password : str
             Password for the Lavalink player.
-        port : int
+        port : Optional[int]
             Port of the Lavalink player event websocket.
         user_id : int
             User ID of the bot.
@@ -162,6 +162,12 @@ class Node:
         self.get_voice_ws = voice_ws_func
         self.host = host
         self.port = port
+        self.secured = secured
+        if self.port is None:
+            if self.secured:
+                self.port = 443
+            else:
+                self.port = 80
         self.password = password
         self._resume_key = resume_key
         if self._resume_key is None:
@@ -170,7 +176,6 @@ class Node:
         self._resuming_configured = False
         self.num_shards = num_shards
         self.user_id = user_id
-        self.secured = secured
 
         self._ready_event = asyncio.Event()
 

--- a/lavalink/node.py
+++ b/lavalink/node.py
@@ -111,7 +111,7 @@ class NodeStats:
 
 class Node:
 
-    _is_shutdown = False  # type: bool
+    _is_shutdown: bool = False
 
     def __init__(
         self,
@@ -124,7 +124,7 @@ class Node:
         num_shards: int,
         port: Optional[int] = None,
         resume_key: Optional[str] = None,
-        resume_timeout: int = 60,
+        resume_timeout: float = 60,
         bot: Bot = None,
         secured: bool = False,
     ):
@@ -151,7 +151,7 @@ class Node:
             Number of shards to which the bot is currently connected.
         resume_key : Optional[str]
             A resume key used for resuming a session upon re-establishing a WebSocket connection to Lavalink.
-        resume_timeout : int
+        resume_timeout : float
             How long the node should wait for a connection while disconnected before clearing all players.
         bot: AutoShardedBot
             The Bot object that connects to discord.
@@ -234,7 +234,7 @@ class Node:
 
         Parameters
         ----------
-        timeout : int
+        timeout : float
             Time after which to timeout on attempting to connect to the Lavalink websocket,
             ``None`` is considered never, but the underlying code may stop trying past a
             certain point.

--- a/lavalink/node.py
+++ b/lavalink/node.py
@@ -162,13 +162,14 @@ class Node:
         self.event_handler = event_handler
         self.get_voice_ws = voice_ws_func
         self.host = host
-        self.port = port
         self.secured = secured
-        if self.port is None:
+        if port is None:
             if self.secured:
                 self.port = 443
             else:
                 self.port = 80
+        else:
+            self.port = port
         self.password = password
         self._resume_key = resume_key
         if self._resume_key is None:

--- a/lavalink/node.py
+++ b/lavalink/node.py
@@ -228,7 +228,7 @@ class Node:
             self._resume_key.__repr__()
             return self._resume_key
 
-    async def connect(self, timeout=None, *, shutdown=False):
+    async def connect(self, timeout: float = None, *, shutdown: bool = False):
         """
         Connects to the Lavalink player event websocket.
 

--- a/lavalink/node.py
+++ b/lavalink/node.py
@@ -115,7 +115,8 @@ class Node:
 
     def __init__(
         self,
-        _loop: asyncio.BaseEventLoop,
+        *,
+        loop: asyncio.BaseEventLoop,
         event_handler: typing.Callable,
         voice_ws_func: typing.Callable,
         host: str,
@@ -133,7 +134,7 @@ class Node:
 
         Parameters
         ----------
-        _loop : asyncio.BaseEventLoop
+        loop : asyncio.BaseEventLoop
             The event loop of the bot.
         event_handler
             Function to dispatch events to.
@@ -156,7 +157,7 @@ class Node:
         bot: AutoShardedBot
             The Bot object that connects to discord.
         """
-        self.loop = _loop
+        self.loop = loop
         self.bot = bot
         self.event_handler = event_handler
         self.get_voice_ws = voice_ws_func

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,7 +139,7 @@ def patch_node(monkeypatch):
 @pytest.fixture
 async def node(bot):
     node_ = lavalink.node.Node(
-        _loop=bot.loop,
+        loop=bot.loop,
         event_handler=MagicMock(),
         voice_ws_func=bot._connection._get_websocket,
         host="localhost",


### PR DESCRIPTION
- rename positional `ws_port` arg in `lavalink.initialize` to  `port`.
- Make port argument in `lavalink.initialize` and `lavalink.node.Node()` optional
- Improve timehints and documentation in a few places

closes #44 