### PR TITLE
Update VoiceProtocol implementation to work with d.py 2.0

### DIFF
--- a/lavalink/lavalink.py
+++ b/lavalink/lavalink.py
@@ -91,7 +91,7 @@ async def initialize(
     return lavalink_node
 
 
-async def connect(channel: discord.VoiceChannel, deafen: bool = False):
+async def connect(channel: discord.VoiceChannel, *, self_deaf: bool = False):
     """
     Connects to a discord voice channel.
 
@@ -102,7 +102,7 @@ async def connect(channel: discord.VoiceChannel, deafen: bool = False):
     ----------
     channel : discord.VoiceChannel
         The channel to connect to.
-    deafen: bool
+    self_deaf: bool
         Whether to deafen the bot user upon join.
 
     Returns
@@ -116,7 +116,7 @@ async def connect(channel: discord.VoiceChannel, deafen: bool = False):
         If there are no available lavalink nodes ready to connect to discord.
     """
     node_ = node.get_node(channel.guild.id)
-    p = await node_.create_player(channel, deafen=deafen)
+    p = await node_.create_player(channel, self_deaf=self_deaf)
     return p
 
 

--- a/lavalink/node.py
+++ b/lavalink/node.py
@@ -505,7 +505,7 @@ class Node:
     def unregister_state_handler(self, func):
         self._state_handlers.remove(func)
 
-    async def create_player(self, channel: VoiceChannel, *, deafen: bool = False) -> Player:
+    async def create_player(self, channel: VoiceChannel, *, self_deaf: bool = False) -> Player:
         """
         Connects to a discord voice channel.
 
@@ -515,7 +515,7 @@ class Node:
         Parameters
         ----------
         channel: VoiceChannel
-        deafen: bool
+        self_deaf: bool
 
         Returns
         -------
@@ -524,11 +524,9 @@ class Node:
         """
         if self._already_in_guild(channel):
             player = self.get_player(channel.guild.id)
-            await player.move_to(channel, deafen=deafen)
+            await player.move_to(channel, self_deaf=self_deaf)
         else:
-            player: Player = await channel.connect(cls=Player)  # type: ignore
-            if deafen:
-                await player.guild.change_voice_state(channel=player.channel, self_deaf=True)
+            player: Player = await channel.connect(cls=Player, self_deaf=self_deaf)  # type: ignore
         return player
 
     def _already_in_guild(self, channel: VoiceChannel) -> bool:

--- a/lavalink/player.py
+++ b/lavalink/player.py
@@ -181,7 +181,12 @@ class Player(RESTClient, VoiceProtocol):
                 raise
 
     async def connect(
-        self, *, timeout: float = 2.0, reconnect: bool = False, deafen: bool = False
+        self,
+        *,
+        timeout: float = 2.0,
+        reconnect: bool = False,
+        self_mute: bool = False,
+        self_deaf: bool = False,
     ) -> None:
         """
         Connects to the voice channel associated with this Player.
@@ -192,24 +197,24 @@ class Player(RESTClient, VoiceProtocol):
         self.node._players_dict[self.guild.id] = self
         await self.node.refresh_player_state(self)
         await self.guild.change_voice_state(
-            channel=self.channel, self_mute=False, self_deaf=deafen
+            channel=self.channel, self_mute=self_mute, self_deaf=self_deaf
         )
 
-    async def move_to(self, channel: discord.VoiceChannel, *, deafen: bool = False) -> None:
+    async def move_to(self, channel: discord.VoiceChannel, *, self_deaf: bool = False) -> None:
         """
         Moves this player to a voice channel.
 
         Parameters
         ----------
         channel : discord.VoiceChannel
-        deafen : bool
+        self_deaf : bool
         """
         if channel.guild != self.guild:
             raise TypeError(f"Cannot move {self!r} to a different guild.")
         if self.channel:
             self._last_channel_id = self.channel.id
         self.channel = channel
-        await self.connect(deafen=deafen)
+        await self.connect(self_deaf=self_deaf)
         if self.current:
             await self.resume(
                 track=self.current, replace=True, start=self.position, pause=self._paused

--- a/lavalink/player.py
+++ b/lavalink/player.py
@@ -119,11 +119,11 @@ class Player(RESTClient, VoiceProtocol):
         """
         return self._connected
 
-    async def on_voice_server_update(self, data: dict) -> None:
+    async def on_voice_server_update(self, data: dict, /) -> None:
         self._pending_server_update = data
         await self._send_lavalink_voice_update()
 
-    async def on_voice_state_update(self, data: dict) -> None:
+    async def on_voice_state_update(self, data: dict, /) -> None:
         self._session_id = data["session_id"]
         if (channel_id := data["channel_id"]) is None:
             ws_rll_log.info("Received voice disconnect from discord, removing player.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 requires-python = ">=3.8.1"
 dependencies = [
     "aiohttp>=3.6.0",
-    "discord.py>=1.5.1",
+    "discord.py>=2.0.0",
     "Red-Commons>=1.0.0,<2",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
See Rapptz/discord.py#7886.

This makes this library *actually* be d.py 2.0 only rather than just d.py 1.5+ as we're now using the new `self_deaf` kwarg in `Connectable.connect()` so I've bumped the minimum d.py version as well.