### PR TITLE
Bump minimum version of d.py to 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 requires-python = ">=3.8.1"
 dependencies = [
     "aiohttp>=3.6.0",
-    "discord.py>=1.5.1",
+    "discord.py>=2.0.0",
     "Red-Commons>=1.0.0,<2",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
See #127. This needs to be merged before we make a non-RC version of 0.11.0.