### PR TITLE
[0.9.x] Avoid infinite iteration over queue on reconnect

### DIFF
--- a/lavalink/node.py
+++ b/lavalink/node.py
@@ -241,9 +241,10 @@ class Node:
         self._listener_task = self.loop.create_task(self.listener())
         self.loop.create_task(self._configure_resume())
         if self._queue:
-            for data in self._queue:
-                await self.send(data)
+            temp = self._queue.copy()
             self._queue.clear()
+            for data in temp:
+                await self.send(data)
         self._ready_event.set()
         self.update_state(NodeState.READY)
 


### PR DESCRIPTION
`Node.send()` may append the element it received *if* the WebSocket is closed which has caused infinite expansion of `Node._queue` over which we iterate in `Node.connect()`.

This fix was already incorporated into `develop` in #117 and this is a backport of that one specific change into 0.9.x branch.

This PR aims to solve the same problem that #129 does but it does it in a way that is less invasive to the existing code base which is preferred for a maintenance release to 0.9.x rather than the main development line. This should make it less likely to cause other issues that would require us to make another release.