### PR TITLE
Bump version to 0.11.0

### DIFF
--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -1,7 +1,7 @@
 from .log import set_logging_level, log, socket_log, ws_discord_log, ws_ll_log, ws_rll_log
 
 set_logging_level()
-__version__ = "0.11.0rc1"
+__version__ = "0.11.0"
 
 from . import utils
 from .lavalink import (


### PR DESCRIPTION
It's only right that we have an actual **stable** release made before releasing 3.5. It's exactly the same as 0.11.0rc1 but that makes sense considering that RC means *release candidate* ;)